### PR TITLE
Implement custom serializer

### DIFF
--- a/CardinalityEstimation.Test/CardinalityEstimation.Test.csproj
+++ b/CardinalityEstimation.Test/CardinalityEstimation.Test.csproj
@@ -51,7 +51,9 @@
   </Choose>
   <ItemGroup>
     <Compile Include="BiasCorrectionTests.cs" />
+    <Compile Include="CardinalityEstimatorSerializerTests.cs" />
     <Compile Include="CardinalityEstimatorTests.cs" />
+    <Compile Include="DictionaryUtils.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/CardinalityEstimation.Test/CardinalityEstimatorSerializerTests.cs
+++ b/CardinalityEstimation.Test/CardinalityEstimatorSerializerTests.cs
@@ -1,0 +1,283 @@
+﻿/*  
+    See https://github.com/Microsoft/CardinalityEstimation.
+    The MIT License (MIT)
+
+    Copyright (c) 2015 Microsoft
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace CardinalityEstimation.Test
+{
+    using System;
+    using System.Diagnostics;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class CardinalityEstimatorSerializer
+    {
+        private const int ElementSizeInBytes = 20;
+        public static readonly Random Rand = new Random();
+
+        private Stopwatch stopwatch;
+
+        [TestInitialize]
+        public void Init()
+        {
+            this.stopwatch = new Stopwatch();
+            this.stopwatch.Start();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            this.stopwatch.Stop();
+            Console.WriteLine("Total test time: {0}", this.stopwatch.Elapsed);
+        }
+
+        private void TestSerializerCreatesSmallerData(int cardinality, out int customSize, out int defaultSize)
+        {
+            var hll = CreationCardinalityEstimator(cardinality);
+
+            var customSerializer = new CardinalityEstimation.CardinalityEstimatorSerializer();
+
+            byte[] customSerializerResults;
+            using (var memoryStream = new MemoryStream())
+            {
+                customSerializer.Serialize(memoryStream, hll);
+                customSerializerResults = memoryStream.ToArray();
+                customSize = customSerializerResults.Length;
+            }
+
+            var binaryFormatter = new BinaryFormatter();
+
+            byte[] defaultSerializerResults;
+            using (var memoryStream = new MemoryStream())
+            {
+                binaryFormatter.Serialize(memoryStream, hll);
+                defaultSerializerResults = memoryStream.ToArray();
+                defaultSize = defaultSerializerResults.Length;
+            }
+            
+            Assert.IsTrue(customSerializerResults.Length <= defaultSerializerResults.Length);
+        }
+
+        [TestMethod]
+        public void TestSerializerCardinality10()
+        {
+            var hll = CreationCardinalityEstimator(10);
+
+            var serializer = new CardinalityEstimation.CardinalityEstimatorSerializer();
+
+            byte[] results;
+            using (var memoryStream = new MemoryStream())
+            {
+                serializer.Serialize(memoryStream, hll);
+
+                results = memoryStream.ToArray();
+            }
+
+
+            // Expected length is 89:
+            // 4 bytes for the Bits in Index
+            // 1 byte for the IsSparse and IsDirectCount flags
+            // 4 bytes for the number of elements in DirectCount
+            // 8 bytes for each element (ulong) in DirectCount
+            Assert.AreEqual(89, results.Length);
+
+
+            Assert.AreEqual(14, BitConverter.ToInt32(results.Take(4).ToArray(), 0)); // Bits in Index = 14
+            Assert.AreEqual(3, results[4]); // IsSparse = true AND IsDirectCount = true
+            Assert.AreEqual(10, BitConverter.ToInt32(results.Skip(5).Take(4).ToArray(), 0)); // Count = 10
+        }
+
+        [TestMethod]
+        public void TestSerializerCardinality1000()
+        {
+            var hll = CreationCardinalityEstimator(1000);
+
+            var serializer = new CardinalityEstimation.CardinalityEstimatorSerializer();
+
+            byte[] results;
+            using (var memoryStream = new MemoryStream())
+            {
+                serializer.Serialize(memoryStream, hll);
+
+                results = memoryStream.ToArray();
+            }
+
+            var data = hll.GetData();
+
+            // Expected length is 2904:
+            // 4 bytes for the Bits in Index 
+            // 1 byte for the IsSparse and IsDirectCount flags
+            // 4 bytes for the number of elements in lookupSparse
+            // 2+1 bytes for each element (ulong) in lookupSparse
+            Assert.AreEqual(9 + 3*data.lookupSparse.Count, results.Length);
+
+
+            Assert.AreEqual(14, BitConverter.ToInt32(results.Take(4).ToArray(), 0)); // Bits in Index = 14
+            Assert.AreEqual(2, results[4]); // IsSparse = true AND IsDirectCount = false
+            Assert.AreEqual(data.lookupSparse.Count, BitConverter.ToInt32(results.Skip(5).Take(4).ToArray(), 0));
+        }
+
+        [TestMethod]
+        public void TestSerializerCardinality100000()
+        {
+            var hll = CreationCardinalityEstimator(100000);
+
+            var serializer = new CardinalityEstimation.CardinalityEstimatorSerializer();
+
+            byte[] results;
+            using (var memoryStream = new MemoryStream())
+            {
+                serializer.Serialize(memoryStream, hll);
+
+                results = memoryStream.ToArray();
+            }
+
+            var data = hll.GetData();
+
+            // Expected length is 2904:
+            // 4 bytes for the Bits in Index 
+            // 1 byte for the IsSparse and IsDirectCount flags
+            // 4 bytes for the number of elements in lookupDense
+            // 1 bytes for each element (ulong) in lookupDense
+            Assert.AreEqual(9 + data.lookupDense.Length, results.Length);
+
+
+            Assert.AreEqual(14, BitConverter.ToInt32(results.Take(4).ToArray(), 0)); // Bits in Index = 14
+            Assert.AreEqual(0, results[4]); // IsSparse = false AND IsDirectCount = false
+            Assert.AreEqual(data.lookupDense.Length, BitConverter.ToInt32(results.Skip(5).Take(4).ToArray(), 0));
+        }
+
+        private void TestDeserializer(int cardinality)
+        {
+            var hll = CreationCardinalityEstimator(cardinality);
+            CardinalityEstimator hll2;
+
+            var serializer = new CardinalityEstimation.CardinalityEstimatorSerializer();
+
+            byte[] results;
+            using (var memoryStream = new MemoryStream())
+            {
+                serializer.Serialize(memoryStream, hll);
+
+                results = memoryStream.ToArray();
+            }
+
+            using (var memoryStream = new MemoryStream(results))
+            {
+                hll2 = serializer.Deserialize(memoryStream);
+            }
+
+            var data = hll.GetData();
+            var data2 = hll2.GetData();
+
+            Assert.AreEqual(data.bitsPerIndex, data2.bitsPerIndex);
+            Assert.AreEqual(data.isSparse, data2.isSparse);
+
+            Assert.IsTrue((data.directCount != null && data2.directCount != null) || (data.directCount == null && data2.directCount == null));
+            Assert.IsTrue((data.lookupSparse != null && data2.lookupSparse != null) || (data.lookupSparse == null && data2.lookupSparse == null));
+            Assert.IsTrue((data.lookupDense != null && data2.lookupDense != null) || (data.lookupDense == null && data2.lookupDense == null));
+
+            if (data.directCount != null)
+            {
+                // DirectCount are subsets of each-other => they are the same set
+                Assert.IsTrue(data.directCount.IsSubsetOf(data2.directCount) && data2.directCount.IsSubsetOf(data.directCount));
+            }
+            if (data.lookupSparse != null)
+            {
+                Assert.IsTrue(data.lookupSparse.DictionaryEqual(data2.lookupSparse));
+            }
+            if (data.lookupDense != null)
+            {
+                Assert.IsTrue(data.lookupDense.SequenceEqual(data2.lookupDense));
+            }
+        }
+
+
+        [TestMethod]
+        public void TestSerializer()
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                TestSerializerCardinality10();
+                TestSerializerCardinality1000();
+                TestSerializerCardinality100000();
+            }
+        }
+
+        [TestMethod]
+        public void TestDeserializer()
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                TestDeserializer(10);
+                TestDeserializer(1000);
+                TestDeserializer(100000);
+            }
+        }
+
+        [TestMethod]
+        public void TestSerializerSizes()
+        {
+            for (int cardinality = 1; cardinality < 10240; cardinality *= 2)
+            {
+                long customTotalSize = 0, defaultTotalSize = 0;
+                int runs = 10;
+                for (int i = 0; i < runs; i++)
+                {
+                    int customSize;
+                    int defaultSize;
+                    TestSerializerCreatesSmallerData(cardinality, out customSize, out defaultSize);
+
+                    customTotalSize += customSize;
+                    defaultTotalSize += defaultSize;
+                }
+
+                long customAverageSize = customTotalSize / runs, defaultAverageSize = defaultTotalSize / runs;
+
+                Console.WriteLine("{0} | {1} | {2} | {3:P}", 
+                    cardinality, customAverageSize, defaultAverageSize,
+                    1-((float)customAverageSize / defaultAverageSize));
+
+            }
+        }
+
+        
+        private CardinalityEstimator CreationCardinalityEstimator(int cardinality = 1000000)
+        {
+            var hll = new CardinalityEstimator();
+
+            var nextMember = new byte[ElementSizeInBytes];
+            for (int i = 0; i < cardinality; i++)
+            {
+                Rand.NextBytes(nextMember);
+                hll.Add(nextMember);
+            }
+
+            return hll;
+        }
+    }
+}

--- a/CardinalityEstimation.Test/DictionaryUtils.cs
+++ b/CardinalityEstimation.Test/DictionaryUtils.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace CardinalityEstimation.Test
+{
+    public static class DictionaryUtils
+    {
+        public static bool DictionaryEqual<TKey, TValue>(this IDictionary<TKey, TValue> first, IDictionary<TKey, TValue> second,
+            IEqualityComparer<TValue> valueComparer = null)
+        {
+            if (first == second) return true;
+            if ((first == null) || (second == null)) return false;
+            if (first.Count != second.Count) return false;
+
+            valueComparer = valueComparer ?? EqualityComparer<TValue>.Default;
+
+            foreach (var kvp in first)
+            {
+                TValue secondValue;
+                if (!second.TryGetValue(kvp.Key, out secondValue)) return false;
+                if (!valueComparer.Equals(kvp.Value, secondValue)) return false;
+            }
+            return true;
+        }
+    }
+}

--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <Compile Include="BiasCorrection.cs" />
     <Compile Include="CardinalityEstimator.cs" />
+    <Compile Include="CardinalityEstimatorSerializer.cs" />
     <Compile Include="ICardinalityEstimator.cs" />
     <Compile Include="InternalsVisible.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/CardinalityEstimation/CardinalityEstimatorSerializer.cs
+++ b/CardinalityEstimation/CardinalityEstimatorSerializer.cs
@@ -1,0 +1,99 @@
+﻿using System.Collections.Generic;
+using System.IO;
+
+namespace CardinalityEstimation
+{
+    class CardinalityEstimatorSerializer
+    {
+        public void Serialize(Stream stream, CardinalityEstimator cardinalityEstimator)
+        {
+            using (var bw = new BinaryWriter(stream))
+            {
+                var data = cardinalityEstimator.GetData();
+
+                bw.Write(data.bitsPerIndex);
+                bw.Write((byte)(((data.isSparse ? 1 : 0) << 1) + (data.directCount != null ? 1 : 0)));
+                if (data.directCount != null)
+                {
+                    bw.Write(data.directCount.Count);
+                    foreach (var element in data.directCount)
+                        bw.Write(element);
+                }
+                else if (data.isSparse)
+                {
+                    bw.Write(data.lookupSparse.Count);
+                    foreach (var element in data.lookupSparse)
+                    {
+                        bw.Write(element.Key);
+                        bw.Write(element.Value);
+                    }
+                }
+                else
+                {
+                    bw.Write(data.lookupDense.Length);
+                    foreach (var element in data.lookupDense)
+                        bw.Write(element);
+                }
+                bw.Flush();
+            }
+        }
+
+        public CardinalityEstimator Deserialize(Stream stream)
+        {
+            using (var br = new BinaryReader(stream))
+            {
+                var bitsPerIndex = br.ReadInt32();
+                var flags = br.ReadByte();
+                var isSparse = ((flags & 2) == 2);
+                var isDirectCount = ((flags & 1) == 1);
+
+                HashSet<ulong> directCount = null;
+                IDictionary<ushort, byte> lookupSparse = null;
+                byte[] lookupDense = null;
+
+                if (isDirectCount)
+                {
+                    var count = br.ReadInt32();
+                    directCount = new HashSet<ulong>();
+
+                    for (int i = 0; i < count; i++)
+                    {
+                        var element = br.ReadUInt64();
+                        directCount.Add(element);
+                    }
+                }
+                else if (isSparse)
+                {
+                    var count = br.ReadInt32();
+                    lookupSparse = new Dictionary<ushort, byte>();
+
+                    for (int i = 0; i < count; i++)
+                    {
+                        var elementKey = br.ReadUInt16();
+                        var elementValue = br.ReadByte();
+                        lookupSparse.Add(elementKey, elementValue);
+                    }
+                }
+                else
+                {
+                    var count = br.ReadInt32();
+                    lookupDense = br.ReadBytes(count);
+                }
+
+                var data = new CardinalityEstimator.CardinalityEstimatorData
+                    {
+                        bitsPerIndex = bitsPerIndex,
+                        directCount = directCount,
+                        isSparse = isSparse,
+                        lookupDense = lookupDense,
+                        lookupSparse = lookupSparse
+                    };
+
+                var result = new CardinalityEstimator(data);
+
+                return result;
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
The custom serializer provides much smaller data (compared to using a `BinaryFormatter`):

| cardinality | custom size | default size | % size reduction |
| --- | --- | --- | --- |
| 1 | 17 | 2651 | 99.36 % |
| 2 | 25 | 2671 | 99.06 % |
| 4 | 41 | 2711 | 98.49 % |
| 8 | 73 | 2791 | 97.38 % |
| 16 | 137 | 2951 | 95.36 % |
| 32 | 265 | 3271 | 91.90 % |
| 64 | 521 | 3911 | 86.68 % |
| 128 | 392 | 3640 | 89.23 % |
| 256 | 771 | 5155 | 85.04 % |
| 512 | 1521 | 8155 | 81.35 % |
| 1024 | 2995 | 14054 | 78.69 % |
| 2048 | 16393 | 17183 | 4.60 % |
| 4096 | 16393 | 17183 | 4.60 % |
| 8192 | 16393 | 17183 | 4.60 % |
| ... | ... | ... |  |

This resolves #3 
