### PR TITLE
Fix a concurrent issue in Murmur3

### DIFF
--- a/CardinalityEstimation/Hash/Murmur3.cs
+++ b/CardinalityEstimation/Hash/Murmur3.cs
@@ -33,25 +33,17 @@ namespace CardinalityEstimation.Hash
     {
         private static readonly ConcurrentStack<Murmur128> pool = new ConcurrentStack<Murmur128>();
 
-        private static Murmur128 Create()
-        {
-            return MurmurHash.Create128(managed: true, preference: AlgorithmPreference.X64);
-        }
-
-
         public ulong GetHashCode(byte[] bytes)
         {
             Murmur128 murmurHash;
             if (!pool.TryPop(out murmurHash))
             {
-                murmurHash = Create();
+                murmurHash = MurmurHash.Create128(managed: true, preference: AlgorithmPreference.X64);
             }
 
-            var result = murmurHash.ComputeHash(bytes);
-
+            byte[] result = murmurHash.ComputeHash(bytes);
             pool.Push(murmurHash);
-
-            return BitConverter.ToUInt64(result,0);
+            return BitConverter.ToUInt64(result, 0);
         }
 
         public HashFunctionId HashFunctionId

--- a/CardinalityEstimation/Hash/Murmur3.cs
+++ b/CardinalityEstimation/Hash/Murmur3.cs
@@ -26,15 +26,32 @@
 namespace CardinalityEstimation.Hash
 {
     using System;
+    using System.Collections.Concurrent;
     using Murmur;
 
     internal class Murmur3 : IHashFunction
     {
-        private static readonly Murmur128 murmurHash = MurmurHash.Create128(managed: true, preference: AlgorithmPreference.X64);
+        private static readonly ConcurrentStack<Murmur128> pool = new ConcurrentStack<Murmur128>();
+
+        private static Murmur128 Create()
+        {
+            return MurmurHash.Create128(managed: true, preference: AlgorithmPreference.X64);
+        }
+
 
         public ulong GetHashCode(byte[] bytes)
         {
-            return BitConverter.ToUInt64(murmurHash.ComputeHash(bytes), 0);
+            Murmur128 murmurHash;
+            if (!pool.TryPop(out murmurHash))
+            {
+                murmurHash = Create();
+            }
+
+            var result = murmurHash.ComputeHash(bytes);
+
+            pool.Push(murmurHash);
+
+            return BitConverter.ToUInt64(result,0);
         }
 
         public HashFunctionId HashFunctionId


### PR DESCRIPTION
MurmurHash implementation is not thread safe,
i.e. calling ComputeHash(bytes) from different threads could create different hash for same value.
