### PR TITLE
Leave serialization stream open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ $tf/
 _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user
+*.sln.DotSettings
 
 # JustCode is a .NET coding addin-in
 .JustCode

--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,6 @@ $tf/
 _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user
-*.sln.DotSettings
 
 # JustCode is a .NET coding addin-in
 .JustCode

--- a/CardinalityEstimation.Test/CardinalityEstimatorSerializerTests.cs
+++ b/CardinalityEstimation.Test/CardinalityEstimatorSerializerTests.cs
@@ -66,7 +66,7 @@ namespace CardinalityEstimation.Test
             byte[] results;
             using (var memoryStream = new MemoryStream())
             {
-                serializer.Serialize(memoryStream, hll);
+                serializer.Serialize(memoryStream, hll, false);
 
                 results = memoryStream.ToArray();
             }
@@ -98,7 +98,7 @@ namespace CardinalityEstimation.Test
             byte[] results;
             using (var memoryStream = new MemoryStream())
             {
-                serializer.Serialize(memoryStream, hll);
+                serializer.Serialize(memoryStream, hll, false);
 
                 results = memoryStream.ToArray();
             }
@@ -132,7 +132,7 @@ namespace CardinalityEstimation.Test
             byte[] results;
             using (var memoryStream = new MemoryStream())
             {
-                serializer.Serialize(memoryStream, hll);
+                serializer.Serialize(memoryStream, hll, false);
 
                 results = memoryStream.ToArray();
             }
@@ -246,7 +246,7 @@ namespace CardinalityEstimation.Test
 
                 using (var memoryStream = new MemoryStream())
                 {
-                    serializer.Serialize(memoryStream, original);
+                    serializer.Serialize(memoryStream, original, false);
                     results = memoryStream.ToArray();
                 }
 
@@ -254,7 +254,7 @@ namespace CardinalityEstimation.Test
                 CardinalityEstimator deserialized;
                 using (var memoryStream = new MemoryStream(results))
                 {
-                    deserialized = serializer.Deserialize(memoryStream);
+                    deserialized = serializer.Deserialize(memoryStream, false);
                 }
 
                 // Add the elements again, should have no effect on state
@@ -331,7 +331,7 @@ namespace CardinalityEstimation.Test
             byte[] customSerializerResults;
             using (var memoryStream = new MemoryStream())
             {
-                customSerializer.Serialize(memoryStream, hll);
+                customSerializer.Serialize(memoryStream, hll, false);
                 customSerializerResults = memoryStream.ToArray();
                 customSize = customSerializerResults.Length;
             }
@@ -359,14 +359,14 @@ namespace CardinalityEstimation.Test
             byte[] results;
             using (var memoryStream = new MemoryStream())
             {
-                serializer.Serialize(memoryStream, hll);
+                serializer.Serialize(memoryStream, hll, false);
 
                 results = memoryStream.ToArray();
             }
 
             using (var memoryStream = new MemoryStream(results))
             {
-                hll2 = serializer.Deserialize(memoryStream);
+                hll2 = serializer.Deserialize(memoryStream, false);
             }
 
             CardinalityEstimatorState data = hll.GetState();

--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -36,6 +36,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/CardinalityEstimation/CardinalityEstimatorSerializer.cs
+++ b/CardinalityEstimation/CardinalityEstimatorSerializer.cs
@@ -28,6 +28,8 @@ namespace CardinalityEstimation
     using System.Collections.Generic;
     using System.IO;
     using System.Runtime.Serialization;
+    using System.Text;
+
     using Hash;
 
     /// <summary>
@@ -48,11 +50,24 @@ namespace CardinalityEstimation
         public const ushort DataFormatMinorVersion = 1;
 
         /// <summary>
-        ///     Serialize the given <paramref name="cardinalityEstimator" /> to <paramref name="stream" />
+        /// Serializes <paramref name="cardinalityEstimator"/> to <paramref name="stream"/>.
         /// </summary>
+        /// <param name="stream">The stream.</param>
+        /// <param name="cardinalityEstimator">The cardinality estimator.</param>
         public void Serialize(Stream stream, CardinalityEstimator cardinalityEstimator)
         {
-            using (var bw = new BinaryWriter(stream))
+            Serialize(stream, cardinalityEstimator, false);
+        }
+
+        /// <summary>
+        /// Serializes <paramref name="cardinalityEstimator"/> to <paramref name="stream"/>.
+        /// </summary>
+        /// <param name="stream">The stream.</param>
+        /// <param name="cardinalityEstimator">The cardinality estimator.</param>
+        /// <param name="leaveOpen">if set to <see langword="true" /> leave the stream open after serialization.</param>
+        public void Serialize(Stream stream, CardinalityEstimator cardinalityEstimator, bool leaveOpen)
+        {
+            using (var bw = new BinaryWriter(stream, Encoding.UTF8, leaveOpen))
             {
                 bw.Write(DataFormatMajorVersion);
                 bw.Write(DataFormatMinorVersion);
@@ -61,7 +76,7 @@ namespace CardinalityEstimation
 
                 bw.Write((byte)data.HashFunctionId);
                 bw.Write(data.BitsPerIndex);
-                bw.Write((byte) (((data.IsSparse ? 1 : 0) << 1) + (data.DirectCount != null ? 1 : 0)));
+                bw.Write((byte)(((data.IsSparse ? 1 : 0) << 1) + (data.DirectCount != null ? 1 : 0)));
                 if (data.DirectCount != null)
                 {
                     bw.Write(data.DirectCount.Count);
@@ -94,11 +109,24 @@ namespace CardinalityEstimation
         }
 
         /// <summary>
-        ///     Deserialize a <see cref="CardinalityEstimator" /> from the given <paramref name="stream" />
+        /// Deserialize a <see cref="CardinalityEstimator" /> from the given <paramref name="stream" />
         /// </summary>
+        /// <param name="stream">The stream.</param>
+        /// <returns>A new CardinalityEstimator.</returns>
         public CardinalityEstimator Deserialize(Stream stream)
         {
-            using (var br = new BinaryReader(stream))
+            return Deserialize(stream, false);
+        }
+
+        /// <summary>
+        /// Deserialize a <see cref="CardinalityEstimator" /> from the given <paramref name="stream" />
+        /// </summary>
+        /// <param name="stream">The stream.</param>
+        /// <param name="leaveOpen">if set to <see langword="true" /> leave the stream open after deserialization.</param>
+        /// <returns>A new CardinalityEstimator.</returns>
+        public CardinalityEstimator Deserialize(Stream stream, bool leaveOpen)
+        {
+            using (var br = new BinaryReader(stream, Encoding.UTF8, leaveOpen))
             {
                 int dataFormatMajorVersion = br.ReadUInt16();
                 int dataFormatMinorVersion = br.ReadUInt16();


### PR DESCRIPTION
On serialization and serialization the stream is closed and disposed of by the BinaryWriter. This is not convenient when one is serializing to a memory stream, because the stream is disposed of when the BinaryWriter is disposed.
This change allows the stream to be detached from the BinaryWriter by exposing the parameters of one of the BinaryWriter's constructors.
I believe the current use of serialization in the tests is buggy, but it is not exposed because of an implementation detail of MemoryStream.