### PR TITLE
Refresh benchmarks to match TFMs

### DIFF
--- a/CardinalityEstimation.Benchmark/CardinalityEstimation.Benchmark.csproj
+++ b/CardinalityEstimation.Benchmark/CardinalityEstimation.Benchmark.csproj
@@ -10,8 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.8" />
-    <PackageReference Include="System.IO.Hashing" Version="8.0.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.3" />
   </ItemGroup>
   
   <ItemGroup>

--- a/CardinalityEstimation.Benchmark/Program.cs
+++ b/CardinalityEstimation.Benchmark/Program.cs
@@ -6,8 +6,8 @@ using BenchmarkDotNet.Running;
 using CardinalityEstimation;
 
 var config = DefaultConfig.Instance
-                .AddJob(Job.Default.WithId("Core70").WithRuntime(CoreRuntime.Core70))
-                .AddJob(Job.Default.WithId("Core80").WithRuntime(CoreRuntime.Core80));
+                .AddJob(Job.Default.WithId("Core80").WithRuntime(CoreRuntime.Core80))
+                .AddJob(Job.Default.WithId("Core90").WithRuntime(CoreRuntime.Core90));
 
 BenchmarkRunner.Run<DifferentHashes>(config);
 


### PR DESCRIPTION
Hi!

Currently, the benchmarks were targeting the old TFMs, this PR bumps the benchmark targets from .NET 7+8 to .NET 8+9.
It also removes unnecessary dependency that is not used directly and upgrades to the latest version of BDN.