### PR TITLE
Add .NET Standard 2.0 build support

### DIFF
--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net8.0;netstandard2.0</TargetFrameworks>
+		<LangVersion>latest</LangVersion>
         <Configurations>Debug;Release;Release-Signed</Configurations>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId Condition=" '$(Configuration)' == 'Release-Signed' ">CardinalityEstimation.Signed</PackageId>

--- a/CardinalityEstimation/CardinalityEstimator.cs
+++ b/CardinalityEstimation/CardinalityEstimator.cs
@@ -27,6 +27,7 @@ namespace CardinalityEstimation
 {
     using System;
     using System.Collections.Generic;
+    using System.Numerics;
     using System.Text;
     using Hash;
 
@@ -214,8 +215,8 @@ namespace CardinalityEstimation
             this.hashFunction = hashFunction;
             if (this.hashFunction == null)
             {
-                this.hashFunction = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x));
-                this.hashFunctionSpan = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x));
+                this.hashFunction = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x), 0);
+                this.hashFunctionSpan = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x), 0);
             }
             else
             {
@@ -237,8 +238,8 @@ namespace CardinalityEstimation
             this.hashFunctionSpan = hashFunctionSpan;
             if (this.hashFunctionSpan == null)
             {
-                this.hashFunction = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x));
-                this.hashFunctionSpan = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x));
+                this.hashFunction = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x), 0);
+                this.hashFunctionSpan = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x), 0);
             }
             else
             {
@@ -846,7 +847,7 @@ namespace CardinalityEstimation
             int knownZeros = 64 - bitsToCount;
 
             var masked = hash & mask;
-            var leadingZeros = (byte)ulong.LeadingZeroCount(masked);
+            var leadingZeros = (byte)BitOperations.LeadingZeroCount(masked);
             return (byte)(leadingZeros - knownZeros + 1);
         }
 

--- a/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
+++ b/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
@@ -168,7 +168,7 @@ namespace CardinalityEstimation
             lockSlim = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
 
             // Init the hash function - use default since we can't get it from the other estimator
-            hashFunction = ((x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x)));
+            hashFunction = ((x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x), 0));
 
             sparseMaxElements = Math.Max(0, (m / 15) - 10);
 
@@ -217,8 +217,8 @@ namespace CardinalityEstimation
             this.hashFunction = hashFunction;
             if (this.hashFunction == null)
             {
-                this.hashFunction = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x));
-                this.hashFunctionSpan = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x));
+                this.hashFunction = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x), 0);
+                this.hashFunctionSpan = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x), 0);
             }
             else
             {
@@ -237,8 +237,8 @@ namespace CardinalityEstimation
             this.hashFunctionSpan = hashFunctionSpan;
             if (this.hashFunction == null)
             {
-                this.hashFunction = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x));
-                this.hashFunctionSpan = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x));
+                this.hashFunction = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x), 0);
+                this.hashFunctionSpan = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x), 0);
             }
         }
 

--- a/CardinalityEstimation/Polyfills/BitOperations.cs
+++ b/CardinalityEstimation/Polyfills/BitOperations.cs
@@ -1,7 +1,7 @@
 ﻿#if !NETCOREAPP3_0_OR_GREATER
 namespace System.Numerics;
 
-public static class BitOperations
+internal static class BitOperations
 {
     public static uint LeadingZeroCount(ulong x)
     {

--- a/CardinalityEstimation/Polyfills/BitOperations.cs
+++ b/CardinalityEstimation/Polyfills/BitOperations.cs
@@ -1,0 +1,26 @@
+﻿#if !NETCOREAPP3_0_OR_GREATER
+namespace System.Numerics;
+
+public static class BitOperations
+{
+    public static uint LeadingZeroCount(ulong x)
+    {
+        x |= x >> 1;
+        x |= x >> 2;
+        x |= x >> 4;
+        x |= x >> 8;
+        x |= x >> 16;
+        x |= x >> 32;
+
+        x -= x >> 1 & 0x5555555555555555;
+        x = (x >> 2 & 0x3333333333333333) + (x & 0x3333333333333333);
+        x = (x >> 4) + x & 0x0f0f0f0f0f0f0f0f;
+        x += x >> 8;
+        x += x >> 16;
+        x += x >> 32;
+
+        const int numLongBits = sizeof(long) * 8;
+        return numLongBits - (uint)(x & 0x0000007f);
+    }
+}
+#endif

--- a/CardinalityEstimation/Polyfills/Linq.cs
+++ b/CardinalityEstimation/Polyfills/Linq.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace System.Linq;
 
-public static class LinqExtensions
+internal static class LinqExtensions
 {
     public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source)
     {

--- a/CardinalityEstimation/Polyfills/Linq.cs
+++ b/CardinalityEstimation/Polyfills/Linq.cs
@@ -1,0 +1,13 @@
+﻿#if !NETCOREAPP2_1_OR_GREATER
+using System.Collections.Generic;
+
+namespace System.Linq;
+
+public static class LinqExtensions
+{
+    public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source)
+    {
+        return new(source);
+    }
+}
+#endif


### PR DESCRIPTION
Hi!

Thank you for building this library. Unfortunately, currently it cannot be used with legacy runtimes like .NET Framework. But since this library does not use many "new" .NET-specific features, adding support for .NET Standard 2.0 (and thus supporting .NET Framework 4.6.2 and later) is quite easy.
The proposed changes include the following:
- add netstandard2.0 TFM along with allowing `latest` language version so the default language version limiter does not kick in
- use `System.Numerics.BitOperations.LeadingZeroCount(ulong)` instead of `ulong.LeadingZeroCount(ulong)` (same functionality, different names) since it's easier to polyfill + polyfilling it with relatively quick implementation that is only used for .NET Standard 2.0
- use `BitConverter.ToUint64` overload that specifies the target index, because only it is available in .NET Standard 2.0 (there is no performance degradation for the "main" case of .NET 8+9, I ran the benchmarks to verify it)
- add `IEnumerable<>.ToHashSet<>` polyfill for .NET Standard 2.0

With these changes, most of the library remains unmodified, the added files are only built for the new TFM and the performance of the existing code is unchanged, but the library can be used by many more developers, who cannot right now target modern versions of .NET for compatibility reasons.

Thanks for taking a look.