### PR TITLE
Minor improvements for AddHashElement

### DIFF
--- a/CardinalityEstimation/CardinalityEstimator.cs
+++ b/CardinalityEstimation/CardinalityEstimator.cs
@@ -111,7 +111,7 @@ namespace CardinalityEstimation
         /// <summary>
         /// Lookup dictionary for the sparse representation of HLL buckets
         /// </summary>
-        private IDictionary<ushort, byte> lookupSparse;
+        private Dictionary<ushort, byte> lookupSparse;
 
         /// <summary>
         /// Max number of elements to hold in the sparse representation before switching to dense
@@ -787,19 +787,24 @@ namespace CardinalityEstimation
             if (isSparse)
             {
                 lookupSparse.TryGetValue(substream, out byte prevRank);
-                lookupSparse[substream] = Math.Max(prevRank, sigma);
-                changed = changed || (prevRank != sigma && lookupSparse[substream] == sigma);
-                if (lookupSparse.Count > sparseMaxElements)
+                if (sigma > prevRank)
                 {
-                    SwitchToDenseRepresentation();
+                    lookupSparse[substream] = sigma;
+                    if (lookupSparse.Count > sparseMaxElements)
+                    {
+                        SwitchToDenseRepresentation();
+                    }
                     changed = true;
                 }
             }
             else
             {
-                var prevMax = lookupDense[substream];
-                lookupDense[substream] = Math.Max(prevMax, sigma);
-                changed = changed || (prevMax != sigma && lookupDense[substream] == sigma);
+                ref var value = ref lookupDense[substream];
+                if (sigma > value)
+                {
+                    value = sigma;
+                    changed = true;
+                }
             }
             return changed;
         }


### PR DESCRIPTION
Hello!

There are small performance improvements worth about 13% speedup for .NET 8+9 on the `AddElementHash` timing in order of effect:
- elide extra bounds check for `lookupDense` using ref var
- tune branching using explicit maximum comparison and mutation checks, especially for repeated additions
- remove the need for devirtualization by replacing private field type of `IDictionary<,>` with `Dictionary<,>` (doesn't actually modify tier1 JIT code, but make JIT's job easier opening potential future optimization)

