### PR TITLE
Expand README with usage, accuracy, threading, merge, serialization, hash, and Span sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ HyperLogLog-based set cardinality estimation library
 This library estimates the number of unique elements in a set, in a quick and memory-efficient manner.  It's based on the following:
 
 1. Flajolet et al., "HyperLogLog: the analysis of a near-optimal cardinality estimation algorithm", DMTCS proc. AH 2007, http://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf
-2. Heule, Nunkesser and Hall 2013, "HyperLogLog in Practice: Algorithmic Engineering of a State of The Art Cardinality Estimation Algorithm", http://static.googleusercontent.com/external_content/untrusted_dlcp/research.google.com/en/us/pubs/archive/40671.pdf
+2. Heule, Nunkesser and Hall 2013, "HyperLogLog in Practice: Algorithmic Engineering of a State of The Art Cardinality Estimation Algorithm", https://research.google/pubs/hyperloglog-in-practice-algorithmic-engineering-of-a-state-of-the-art-cardinality-estimation-algorithm/
 
 The accuracy/memory usage are user-selectable.  Typically, a cardinality estimator will give a perfect estimate of small cardinalities (up to 100 unique elements), and 97% accuracy or better (usually much better) for any cardinality up to near 2^64, while consuming several KB of memory (no more than 16KB).
 
@@ -18,23 +18,158 @@ ICardinalityEstimator<string> estimator = new CardinalityEstimator();
 
 estimator.Add("Alice");
 estimator.Add("Bob");
-estimator.Add("Alice");
+estimator.Add("Alice"); // duplicate — already counted
 estimator.Add("George Michael");
 
-ulong numberOfuniqueElements = estimator.Count(); // will be 3
+ulong numberOfuniqueElements = estimator.Count(); // will be 3 — "Alice" was added twice but counted once
 ```
 
 ## Nuget Package
 
-This code is available as the Nuget package [CardinalityEstimation](https://www.nuget.org/packages/CardinalityEstimation/). 
+This code is available as the Nuget package [CardinalityEstimation](https://www.nuget.org/packages/CardinalityEstimation/). A strong-named build is also published as [CardinalityEstimation.Signed](https://www.nuget.org/packages/CardinalityEstimation.Signed/).
 
-To install, run the following command in the Package Manager Console:
+To install, use the .NET CLI:
+
+```bash
+dotnet add package CardinalityEstimation
+```
+
+Or, equivalently, the Package Manager Console in Visual Studio:
 
 ```powershell
 Install-Package CardinalityEstimation
 ```
 
+## Controlling Accuracy and Memory
+
+The constructor accepts a `b` parameter that controls the tradeoff between accuracy and memory:
+
+```csharp
+// b = 14 (default) — ~3% standard error or better, up to ~16 KB per estimator
+var estimator = new CardinalityEstimator(b: 14);
+
+// b = 4 — minimum, < 1 KB but high error (up to ~100%)
+var tinyEstimator = new CardinalityEstimator(b: 4);
+
+// b = 16 — maximum, ~1% error or better, up to ~64 KB
+var preciseEstimator = new CardinalityEstimator(b: 16);
+```
+
+`b` must be in the range `[4, 16]`. The standard error for large cardinalities is approximately `1.04 * 2^(-b/2)`, and memory consumption is bounded by `2^b` bytes for the dense representation. The estimator gives **perfect** counts for the first 100 elements regardless of `b`, then transitions to a sparse representation, and finally to the dense HyperLogLog representation as cardinality grows.
+
+## Hash Functions
+
+By default the estimator uses `XxHash128` (from `System.IO.Hashing`), which is fast and has excellent distribution properties. Two alternatives ship in the box:
+
+- `Murmur3` (`CardinalityEstimation.Hash.Murmur3`)
+- `FNV-1a` (`CardinalityEstimation.Hash.Fnv1A`)
+
+You can supply your own `GetHashCodeDelegate` to the constructor:
+
+```csharp
+using CardinalityEstimation;
+using CardinalityEstimation.Hash;
+
+GetHashCodeDelegate murmur = Murmur3.GetHashCode;
+var estimator = new CardinalityEstimator(hashFunction: murmur);
+```
+
+The hash must be a 64-bit hash with good distribution — biased hashes will degrade estimate accuracy. When merging or deserializing estimators, all participants must have been built with the same hash function.
+
+## Thread-Safe Usage
+
+`CardinalityEstimator` is **not** thread-safe. For concurrent producers, use `ConcurrentCardinalityEstimator`, which wraps the same algorithm with a `ReaderWriterLockSlim`:
+
+```csharp
+var estimator = new ConcurrentCardinalityEstimator();
+
+Parallel.ForEach(events, e => estimator.Add(e.UserId));
+
+ulong uniqueUsers = estimator.Count();
+```
+
+Use `ConcurrentCardinalityEstimator` when multiple threads add to (or read from) the same estimator concurrently. If each thread owns its own estimator and you only combine results at the end, the basic `CardinalityEstimator` is faster — combine them with `Merge` (see below).
+
+## Merging Estimators
+
+Estimators built with the same `b` and the same hash function can be merged losslessly. This is the core primitive for distributed and parallel cardinality counting — partition your data, count each shard independently, then merge:
+
+```csharp
+var a = new CardinalityEstimator();
+var b = new CardinalityEstimator();
+
+a.Add("Alice"); a.Add("Bob");
+b.Add("Bob");   b.Add("Carol");
+
+// In-place merge of b into a
+a.Merge(b);
+ulong unique = a.Count(); // 3
+
+// Static merge of many estimators into a new one
+CardinalityEstimator combined = CardinalityEstimator.Merge(new[] { a, b });
+```
+
+For large numbers of estimators you can merge them in parallel via the extension method in `CardinalityEstimatorExtensions`:
+
+```csharp
+using CardinalityEstimation;
+
+ConcurrentCardinalityEstimator merged = shardEstimators.ParallelMerge();
+```
+
+`ParallelMerge` returns a `ConcurrentCardinalityEstimator` and uses all available cores by default; pass `parallelismDegree` to cap it.
+
+## Serialization
+
+Use `CardinalityEstimatorSerializer` to persist an estimator to a stream and restore it later (e.g. to checkpoint state, ship it across the wire, or store it in a cache):
+
+```csharp
+var serializer = new CardinalityEstimatorSerializer();
+
+// Serialize
+using (var stream = File.Create("estimator.bin"))
+{
+    serializer.Serialize(stream, estimator);
+}
+
+// Deserialize — pass the same hash function the estimator was built with
+using (var stream = File.OpenRead("estimator.bin"))
+{
+    CardinalityEstimator restored = serializer.Deserialize(stream);
+}
+```
+
+The serializer uses a versioned binary format (see `DataFormatMajorVersion` / `DataFormatMinorVersion` in `CardinalityEstimatorSerializer`) so newer minor versions can read older payloads of the same major version.
+
+## Zero-Allocation / High-Performance
+
+For hot paths where you already have bytes (e.g. from a buffer pool, a network packet, or `stackalloc`), `CardinalityEstimator` implements `ICardinalityEstimatorMemory`, which exposes `Add` overloads for `Span<byte>`, `ReadOnlySpan<byte>`, `Memory<byte>`, and `ReadOnlyMemory<byte>`:
+
+```csharp
+ICardinalityEstimatorMemory estimator = new CardinalityEstimator();
+
+Span<byte> buffer = stackalloc byte[16];
+// ...fill buffer...
+estimator.Add(buffer); // no allocation
+```
+
+These overloads route through a `GetHashCodeSpanDelegate` and avoid the byte-array allocation of the legacy path.
+
 ## Release Notes
+
+### 1.14.0
+- Added support for `Span<byte>`, `ReadOnlySpan<byte>`, `Memory<byte>`, and `ReadOnlyMemory<byte>` via `ICardinalityEstimatorMemory` (zero-allocation hot path).
+- Added `ConcurrentCardinalityEstimator` for thread-safe usage, plus `ParallelMerge` / `SafeMerge` extensions.
+- Updated and expanded XML documentation.
+
+### 1.13.0
+- Switched the default hash function to `XxHash128` (from `System.IO.Hashing`) on .NET 8+ for better speed and distribution. `Murmur3` and `FNV-1a` remain available.
+- Optimized `GetSigma` on .NET 8.
+
+### 1.12.0
+- Targets `net8.0` and `net9.0`; dropped support for end-of-life .NET versions.
+- Added the `CardinalityEstimation.Benchmark` project (BenchmarkDotNet).
+- Made the hashing classes (`Murmur3`, `Fnv1A`) public.
 
 ## Keeping things friendly
 


### PR DESCRIPTION
## Issue
The README was missing key documentation for features that have shipped on the `version-1.15` line and earlier:
- empty **Release Notes** section
- no guidance on tuning accuracy/memory (the `b` parameter)
- no mention of `ConcurrentCardinalityEstimator` for thread-safe usage
- no examples for `Merge` / `ParallelMerge`
- no examples for `CardinalityEstimatorSerializer.Serialize` / `Deserialize`
- no mention of the zero-allocation `ICardinalityEstimatorMemory` (Span/Memory) overloads
- no mention of the default hash (XxHash128) or how to swap in `Murmur3` / `Fnv1A`
- dead reference link (`static.googleusercontent.com/external_content/untrusted_dlcp/...`) for the Heule et al. paper
- only `Install-Package` shown; `dotnet add package` is more universally applicable today
- the basic usage example's `// will be 3` comment didn't make the deduplication behavior explicit

## Fix
Expanded `README.md` with new sections:
- **Controlling Accuracy and Memory** — explains the `b` parameter (range 4–16, default 14, ~3% error, up to ~16 KB)
- **Hash Functions** — documents the `XxHash128` default, the available `Murmur3` and `Fnv1A` alternatives, and how to pass a custom `GetHashCodeDelegate`
- **Thread-Safe Usage** — `ConcurrentCardinalityEstimator` example with guidance on when to prefer it over the basic estimator
- **Merging Estimators** — examples for instance `Merge`, static `CardinalityEstimator.Merge`, and the `ParallelMerge` extension
- **Serialization** — `CardinalityEstimatorSerializer.Serialize` / `Deserialize` with a stream
- **Zero-Allocation / High-Performance** — `ICardinalityEstimatorMemory` and the `Span<byte>` / `ReadOnlySpan<byte>` / `Memory<byte>` / `ReadOnlyMemory<byte>` overloads
- **Release Notes** — version history for 1.14.0 (Span/Memory + `ConcurrentCardinalityEstimator`), 1.13.0 (XxHash128 default), and 1.12.0 (.NET 8/9 targets, public hashers, benchmarks)

Also:
- Replaced the dead `static.googleusercontent.com` link with the live `https://research.google/pubs/...` URL
- Added `dotnet add package CardinalityEstimation` alongside the existing `Install-Package` instruction
- Reworded the basic usage comment to call out that `Alice` was added twice but counted once

## Tests
None — this is a docs-only change with no behavioral impact. Verified `dotnet build CardinalityEstimation\CardinalityEstimation.csproj -c Release` still succeeds (README is packed into the nupkg via the `<None Include=..\README.md Pack=true ...>` item).

## Other changes
- Updated `README.md` with release notes for 1.12 / 1.13 / 1.14.
- **No version bump** — accumulates on `version-1.15`.
