### PR TITLE
Clarify ICardinalityEstimatorMemory and CreateMultiple XML doc comments

### DIFF
--- a/CardinalityEstimation/CardinalityEstimatorExtensions.cs
+++ b/CardinalityEstimation/CardinalityEstimatorExtensions.cs
@@ -159,7 +159,12 @@ namespace CardinalityEstimation
         /// All estimators will use the same hash function for compatibility.
         /// </param>
         /// <param name="b">
-        /// Accuracy parameter for all estimators. Must be in the range [4, 16].
+        /// Number of bits determining accuracy and memory consumption for all estimators, in the range [4, 16]
+        /// (higher = greater accuracy and memory usage). For large cardinalities, the standard error is
+        /// 1.04 * 2^(-b/2), and the memory consumption is bounded by 2^b kilobytes. The default value of 14
+        /// typically yields 3% error or less across the entire range of cardinalities (usually much less),
+        /// and uses up to ~16kB of memory. b=4 yields less than ~100% error and uses less than 1kB.
+        /// b=16 uses up to ~64kB and usually yields 1% error or less.
         /// All estimators will have the same accuracy to ensure they can be merged.
         /// </param>
         /// <param name="useDirectCounting">

--- a/CardinalityEstimation/ICardinalityEstimatorMemory.cs
+++ b/CardinalityEstimation/ICardinalityEstimatorMemory.cs
@@ -28,36 +28,61 @@ using System;
 namespace CardinalityEstimation
 {
     /// <summary>
-    /// Advanced generic cardinality estimator interface with performance optimizations
+    /// Advanced generic cardinality estimator interface with performance optimizations.
     /// </summary>
+    /// <remarks>
+    /// The <c>Span&lt;byte&gt;</c> and <c>ReadOnlySpan&lt;byte&gt;</c> overloads are the
+    /// true zero-allocation entry points: the implementation hashes the data directly
+    /// without copying it to the heap. The <c>Memory&lt;byte&gt;</c> and
+    /// <c>ReadOnlyMemory&lt;byte&gt;</c> overloads avoid the byte-array allocation of
+    /// the legacy <c>byte[]</c> path, but the underlying <see cref="System.Memory{T}"/>
+    /// itself may already reference heap-allocated storage (for example, when it wraps
+    /// a managed array). For the lowest-allocation hot paths, prefer the
+    /// <see cref="System.Span{T}"/> / <see cref="System.ReadOnlySpan{T}"/> overloads
+    /// (e.g. backed by <c>stackalloc</c> or a pooled buffer's span).
+    /// </remarks>
     public interface ICardinalityEstimatorMemory
     {
         /// <summary>
-        /// Add data from a Span&lt;byte&gt; with zero allocations
+        /// Add data from a Span&lt;byte&gt; without allocating; the data is hashed in place.
         /// </summary>
         /// <param name="data">The byte data to add</param>
         /// <returns>True if estimator's state was modified. False otherwise</returns>
         bool Add(Span<byte> data);
 
         /// <summary>
-        /// Add data from a ReadOnlySpan&lt;byte&gt; with zero allocations
+        /// Add data from a ReadOnlySpan&lt;byte&gt; without allocating; the data is hashed in place.
         /// </summary>
         /// <param name="data">The byte data to add</param>
         /// <returns>True if estimator's state was modified. False otherwise</returns>
         bool Add(ReadOnlySpan<byte> data);
 
         /// <summary>
-        /// Add data from Memory&lt;byte&gt; with optimized allocation patterns
+        /// Add data from a Memory&lt;byte&gt;.
         /// </summary>
         /// <param name="data">The byte data to add</param>
         /// <returns>True if estimator's state was modified. False otherwise</returns>
+        /// <remarks>
+        /// The hash itself is computed without additional allocation, but
+        /// <see cref="System.Memory{T}"/> can reference heap-allocated storage. For a
+        /// truly allocation-free call site (for example over a <c>stackalloc</c> buffer),
+        /// prefer the <see cref="Add(System.Span{byte})"/> or
+        /// <see cref="Add(System.ReadOnlySpan{byte})"/> overloads.
+        /// </remarks>
         bool Add(Memory<byte> data);
 
         /// <summary>
-        /// Add data from ReadOnlyMemory&lt;byte&gt; with optimized allocation patterns
+        /// Add data from a ReadOnlyMemory&lt;byte&gt;.
         /// </summary>
         /// <param name="data">The byte data to add</param>
         /// <returns>True if estimator's state was modified. False otherwise</returns>
+        /// <remarks>
+        /// The hash itself is computed without additional allocation, but
+        /// <see cref="System.ReadOnlyMemory{T}"/> can reference heap-allocated storage.
+        /// For a truly allocation-free call site (for example over a <c>stackalloc</c>
+        /// buffer), prefer the <see cref="Add(System.Span{byte})"/> or
+        /// <see cref="Add(System.ReadOnlySpan{byte})"/> overloads.
+        /// </remarks>
         bool Add(ReadOnlyMemory<byte> data);
     }
 }


### PR DESCRIPTION
## Issue
Two XML doc nits in the public surface:

1. `ICardinalityEstimatorMemory` — the per-overload summaries claim the `Span<byte>` and `ReadOnlySpan<byte>` `Add` methods work `with zero allocations`, and that the `Memory<byte>` / `ReadOnlyMemory<byte>` overloads work `with optimized allocation patterns`. The latter phrasing is slightly misleading: `Memory<byte>` can still reference heap-allocated storage, so callers shouldn't treat those overloads as a true zero-allocation path.
2. `CardinalityEstimatorExtensions.CreateMultiple` — the `b` parameter doc only says `Must be in the range [4, 16]` and doesn't mention the default (14) or what `b` means for accuracy / memory, so it's inconsistent with the much richer doc on the `CardinalityEstimator` constructor.

## Fix
- `ICardinalityEstimatorMemory.cs`: reworded the per-overload summaries and added an interface-level `<remarks>` block explaining that `Span<byte>` / `ReadOnlySpan<byte>` are the true zero-allocation entry points, while the `Memory` overloads avoid only the byte-array copy of the legacy path. Each `Memory` overload's doc now points back at the `Span` overloads for the lowest-allocation hot path.
- `CardinalityEstimatorExtensions.cs`: expanded the `CreateMultiple` `b` param doc to include the default (14), the `1.04 * 2^(-b/2)` standard-error formula, and the memory bounds — mirroring the wording on the `CardinalityEstimator` constructor.

## Tests
None — XML doc comment changes have no behavioral impact and aren't covered by tests in this repo. Verified `dotnet build CardinalityEstimation\CardinalityEstimation.csproj` succeeds with no new warnings (the project doesn't enable doc-comment warnings, but the cref targets are real).

## Other changes
- **No version bump** — accumulates on `version-1.15`.
