### PR TITLE
Validate CardinalityEstimatorSerializer input to prevent DoS

### DIFF
--- a/CardinalityEstimation.Test/CardinalityEstimatorSerializerTests.cs
+++ b/CardinalityEstimation.Test/CardinalityEstimatorSerializerTests.cs
@@ -442,5 +442,107 @@ namespace CardinalityEstimation.Test
                 Assert.True(data.LookupDense.SequenceEqual(data2.LookupDense));
             }
         }
+
+        // Header for current format (major=3, minor=1) with the given bitsPerIndex and flags.
+        private static void WriteHeader(BinaryWriter bw, int bitsPerIndex, byte flags)
+        {
+            bw.Write((ushort)CardinalityEstimatorSerializer.DataFormatMajorVersion);
+            bw.Write((ushort)CardinalityEstimatorSerializer.DataFormatMinorVersion);
+            bw.Write(bitsPerIndex);
+            bw.Write(flags);
+        }
+
+        [Theory]
+        [InlineData(3)]    // below minimum
+        [InlineData(17)]   // above maximum
+        [InlineData(30)]   // attacker value: m = 2^30 ~ 1 GB
+        [InlineData(-1)]   // negative
+        public void Deserialize_RejectsOutOfRangeBitsPerIndex(int bitsPerIndex)
+        {
+            using var ms = new MemoryStream();
+            using (var bw = new BinaryWriter(ms, System.Text.Encoding.UTF8, leaveOpen: true))
+            {
+                WriteHeader(bw, bitsPerIndex, flags: 0);
+            }
+            ms.Position = 0;
+
+            var serializer = new CardinalityEstimatorSerializer();
+            Assert.Throws<InvalidDataException>(() => serializer.Deserialize(ms));
+        }
+
+        [Fact]
+        public void Deserialize_RejectsOversizedDirectCount()
+        {
+            using var ms = new MemoryStream();
+            using (var bw = new BinaryWriter(ms, System.Text.Encoding.UTF8, leaveOpen: true))
+            {
+                WriteHeader(bw, bitsPerIndex: 14, flags: 1); // isDirectCount=true
+                bw.Write(int.MaxValue);                       // attacker-supplied count
+            }
+            ms.Position = 0;
+
+            var serializer = new CardinalityEstimatorSerializer();
+            Assert.Throws<InvalidDataException>(() => serializer.Deserialize(ms));
+        }
+
+        [Fact]
+        public void Deserialize_RejectsNegativeDirectCount()
+        {
+            using var ms = new MemoryStream();
+            using (var bw = new BinaryWriter(ms, System.Text.Encoding.UTF8, leaveOpen: true))
+            {
+                WriteHeader(bw, bitsPerIndex: 14, flags: 1); // isDirectCount=true
+                bw.Write(-1);
+            }
+            ms.Position = 0;
+
+            var serializer = new CardinalityEstimatorSerializer();
+            Assert.Throws<InvalidDataException>(() => serializer.Deserialize(ms));
+        }
+
+        [Fact]
+        public void Deserialize_RejectsOversizedSparseCount()
+        {
+            using var ms = new MemoryStream();
+            using (var bw = new BinaryWriter(ms, System.Text.Encoding.UTF8, leaveOpen: true))
+            {
+                WriteHeader(bw, bitsPerIndex: 14, flags: 2); // isSparse=true
+                bw.Write(int.MaxValue);                       // attacker-supplied count
+            }
+            ms.Position = 0;
+
+            var serializer = new CardinalityEstimatorSerializer();
+            Assert.Throws<InvalidDataException>(() => serializer.Deserialize(ms));
+        }
+
+        [Fact]
+        public void Deserialize_RejectsOversizedDenseCount()
+        {
+            using var ms = new MemoryStream();
+            using (var bw = new BinaryWriter(ms, System.Text.Encoding.UTF8, leaveOpen: true))
+            {
+                WriteHeader(bw, bitsPerIndex: 14, flags: 0); // dense
+                bw.Write(int.MaxValue);                       // attacker-supplied count != m
+            }
+            ms.Position = 0;
+
+            var serializer = new CardinalityEstimatorSerializer();
+            Assert.Throws<InvalidDataException>(() => serializer.Deserialize(ms));
+        }
+
+        [Fact]
+        public void Deserialize_RejectsDenseCountThatDoesNotMatchM()
+        {
+            using var ms = new MemoryStream();
+            using (var bw = new BinaryWriter(ms, System.Text.Encoding.UTF8, leaveOpen: true))
+            {
+                WriteHeader(bw, bitsPerIndex: 14, flags: 0); // dense, m = 16384
+                bw.Write(16383);                               // off by one
+            }
+            ms.Position = 0;
+
+            var serializer = new CardinalityEstimatorSerializer();
+            Assert.Throws<InvalidDataException>(() => serializer.Deserialize(ms));
+        }
     }
 }

--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -5,7 +5,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId Condition=" '$(Configuration)' == 'Release-Signed' ">CardinalityEstimation.Signed</PackageId>
         <PackageId Condition=" '$(Configuration)' == 'Release' OR '$(Configuration)' == 'Debug' ">CardinalityEstimation</PackageId>
-        <Version>1.14.0</Version>
+        <Version>1.15.0</Version>
         <Description>A C# library to estimate the number of unique elements in a set, in a quick and memory-efficient manner, based on the work of Flajolet et al. and Huele et al. Signed version.</Description>
         <Authors>Oron Navon;Sagui Itay</Authors>
         <Company></Company>
@@ -14,12 +14,9 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <Copyright>Copyright © Sagui Itay 2022</Copyright>
         <PackageTags>hyperloglog cardinality estimation loglog set c# cardinalityestimation</PackageTags>
-        <PackageReleaseNotes>Added support for Span/ReadOnlySpan/Memory/ReadOnlyMemory
-Added ConcurrentCardinalityEstimator
-Hardened CardinalityEstimatorSerializer against DoS via maliciously crafted input (validates bitsPerIndex and all length-prefixed counts before allocating)
-Updated XML docs</PackageReleaseNotes>
-        <AssemblyVersion>1.14.0.0</AssemblyVersion>
-        <FileVersion>1.14.0.0</FileVersion>
+        <PackageReleaseNotes>Hardened CardinalityEstimatorSerializer against DoS via maliciously crafted input (validates bitsPerIndex and all length-prefixed counts before allocating)</PackageReleaseNotes>
+        <AssemblyVersion>1.15.0.0</AssemblyVersion>
+        <FileVersion>1.15.0.0</FileVersion>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>

--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -16,6 +16,7 @@
         <PackageTags>hyperloglog cardinality estimation loglog set c# cardinalityestimation</PackageTags>
         <PackageReleaseNotes>Added support for Span/ReadOnlySpan/Memory/ReadOnlyMemory
 Added ConcurrentCardinalityEstimator
+Hardened CardinalityEstimatorSerializer against DoS via maliciously crafted input (validates bitsPerIndex and all length-prefixed counts before allocating)
 Updated XML docs</PackageReleaseNotes>
         <AssemblyVersion>1.14.0.0</AssemblyVersion>
         <FileVersion>1.14.0.0</FileVersion>

--- a/CardinalityEstimation/CardinalityEstimatorSerializer.cs
+++ b/CardinalityEstimation/CardinalityEstimatorSerializer.cs
@@ -255,6 +255,15 @@ namespace CardinalityEstimation
             }
 
             int bitsPerIndex = reader.ReadInt32();
+            if (bitsPerIndex < 4 || bitsPerIndex > 16)
+            {
+                throw new InvalidDataException(
+                    $"Invalid serialized data: bitsPerIndex must be in the range [4, 16], got {bitsPerIndex}.");
+            }
+            // Maximum number of HLL substreams for the negotiated bitsPerIndex.
+            // Safe to compute as int because bitsPerIndex <= 16 (m <= 65536).
+            int m = 1 << bitsPerIndex;
+
             byte flags = reader.ReadByte();
             bool isSparse = (flags & 2) == 2;
             bool isDirectCount = (flags & 1) == 1;
@@ -266,6 +275,14 @@ namespace CardinalityEstimation
             if (isDirectCount)
             {
                 int count = reader.ReadInt32();
+                // Must match CardinalityEstimator.DirectCounterMaxElements (100); a higher value
+                // would mean the writer should have transitioned to the sparse/dense representation.
+                const int maxDirectCount = 100;
+                if (count < 0 || count > maxDirectCount)
+                {
+                    throw new InvalidDataException(
+                        $"Invalid serialized data: directCount length must be in the range [0, {maxDirectCount}], got {count}.");
+                }
                 directCount = new HashSet<ulong>();
 
                 for (var i = 0; i < count; i++)
@@ -277,6 +294,12 @@ namespace CardinalityEstimation
             else if (isSparse)
             {
                 int count = reader.ReadInt32();
+                // Sparse entries are keyed by ushort substream index; there can be at most m of them.
+                if (count < 0 || count > m)
+                {
+                    throw new InvalidDataException(
+                        $"Invalid serialized data: sparse lookup length must be in the range [0, {m}], got {count}.");
+                }
 
                 for (var i = 0; i < count; i++)
                 {
@@ -288,7 +311,18 @@ namespace CardinalityEstimation
             else
             {
                 int count = reader.ReadInt32();
+                // The dense lookup is always exactly m bytes long for the negotiated bitsPerIndex.
+                if (count != m)
+                {
+                    throw new InvalidDataException(
+                        $"Invalid serialized data: dense lookup length must equal m={m} for bitsPerIndex={bitsPerIndex}, got {count}.");
+                }
                 lookupDense = reader.ReadBytes(count);
+                if (lookupDense.Length != count)
+                {
+                    throw new EndOfStreamException(
+                        $"Truncated serialized data: expected {count} bytes for dense lookup, got {lookupDense.Length}.");
+                }
             }
 
             // Starting with version 2.1, the serializer writes CountAdditions

--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ These overloads route through a `GetHashCodeSpanDelegate` and avoid the byte-arr
 
 ## Release Notes
 
+### 1.15.0
+- Hardened `CardinalityEstimatorSerializer` against denial-of-service via a maliciously crafted input stream: `bitsPerIndex` and all length-prefixed counts (direct / sparse / dense) are now validated before any allocation.
+
 ### 1.14.0
 - Added support for `Span<byte>`, `ReadOnlySpan<byte>`, `Memory<byte>`, and `ReadOnlyMemory<byte>` via `ICardinalityEstimatorMemory` (zero-allocation hot path).
 - Added `ConcurrentCardinalityEstimator` for thread-safe usage, plus `ParallelMerge` / `SafeMerge` extensions.


### PR DESCRIPTION
## Issue
**Vulnerability: Denial-of-Service via Deserialization Memory Exhaustion**
Location: `CardinalityEstimation/CardinalityEstimatorSerializer.cs` — `Read` method.

The binary deserializer read `count` values and `bitsPerIndex` directly from an untrusted stream without any validation. A crafted stream could cause:

- `bitsPerIndex = 30` → `m = 2^30` ≈ 1 billion → allocate ~1 GB for `lookupDense`
- `count = Int32.MaxValue` for `directCount` → loop ~2 billion iterations reading 8 bytes each
- `count = Int32.MaxValue` for `lookupDense` → `ReadBytes(Int32.MaxValue)` → attempt to allocate ~2 GB
- `count > m` for `lookupSparse` → wasted reads / possible OOM

## Fix
Validate everything that drives an allocation or loop bound before using it, and throw `InvalidDataException` on bad data:

- `bitsPerIndex` must be in `[4, 16]` — matches the range enforced by the `CardinalityEstimator` constructor; fails the 1 GB `m = 2^30` attack.
- `directCount` length must be in `[0, 100]` — matches `CardinalityEstimator.DirectCounterMaxElements`; a higher value would mean the writer should have transitioned to sparse/dense.
- `lookupSparse` length must be in `[0, m]` where `m = 2^bitsPerIndex` — keys are `ushort` substream indices and there can be at most `m` of them.
- `lookupDense` length must equal `m` exactly — the dense lookup is always exactly `m` bytes for the negotiated `bitsPerIndex`.
- Also detects a truncated dense payload (`ReadBytes` returning fewer bytes than requested) and throws `EndOfStreamException` instead of silently returning a short array.

Negative `int` counts (`ReadInt32` can return negative values) are rejected by the same range checks.

## Tests
Added 8 new regression tests in `CardinalityEstimation.Test/CardinalityEstimatorSerializerTests.cs`:

- `Deserialize_RejectsOutOfRangeBitsPerIndex` (`[Theory]` with 4 cases: 3, 17, **30** — the attacker-named value, and -1)
- `Deserialize_RejectsOversizedDirectCount` (`Int32.MaxValue`)
- `Deserialize_RejectsNegativeDirectCount`
- `Deserialize_RejectsOversizedSparseCount` (`Int32.MaxValue`)
- `Deserialize_RejectsOversizedDenseCount` (`Int32.MaxValue`)
- `Deserialize_RejectsDenseCountThatDoesNotMatchM`

Each test crafts a header with the malicious value and asserts `InvalidDataException`. On the pre-fix code these would either `OutOfMemoryException` (the dense / sparse / direct-count blow-up cases), hang (the directCount loop), or silently produce a corrupted estimator (the `bitsPerIndex` and dense-size-mismatch cases) — i.e. they are true regression tests for this CVE-class issue.

Full suite: **130 passed, 1 skipped, 0 failed** on both `net8.0` and `net9.0`.

## Other changes
- Added a security bullet to `README.md` under a new `### 1.15.0` section and to `<PackageReleaseNotes>` in `CardinalityEstimation.csproj`.
- **No version bump** — accumulates on `version-1.15`.
