### PR TITLE
Fix ConcurrentCardinalityEstimator direct-count perf: replace ConcurrentBag with ConcurrentDictionary

### DIFF
--- a/CardinalityEstimation.Test/ConcurrentCardinalityEstimatorTests.cs
+++ b/CardinalityEstimation.Test/ConcurrentCardinalityEstimatorTests.cs
@@ -504,5 +504,94 @@ namespace CardinalityEstimation.Test
                 estimator.Dispose();
             }
         }
+
+        // Regression tests for the direct-count storage. Previously backed by ConcurrentBag<ulong>,
+        // which permits duplicates and forced every Add/Count/Merge/Equals path to call .Distinct()
+        // (allocating + O(n)). The storage is now a ConcurrentDictionary<ulong, byte> used as a
+        // concurrent hash set, so duplicates simply collapse and Count is O(1).
+
+        [Fact]
+        public void DirectCount_ConcurrentDuplicateAdds_DeduplicatesExactly()
+        {
+            // Arrange - stay below DirectCounterMaxElements (100) so we exercise the direct-count path.
+            using var estimator = new ConcurrentCardinalityEstimator(b: 14);
+            const int distinctCount = 50;
+            const int duplicatesPerElement = 200;
+
+            // Act - many threads pushing the same set of values repeatedly.
+            Parallel.For(0, distinctCount * duplicatesPerElement, i =>
+            {
+                estimator.Add($"element_{i % distinctCount}");
+            });
+
+            // Assert - direct counter is exact, so Count must equal the number of distinct strings,
+            // regardless of how many duplicate adds raced.
+            Assert.Equal((ulong)distinctCount, estimator.Count());
+            Assert.Equal((ulong)(distinctCount * duplicatesPerElement), estimator.CountAdditions);
+        }
+
+        [Fact]
+        public void DirectCount_TransitionsToSparse_AtCorrectThreshold()
+        {
+            // Arrange - DirectCounterMaxElements is 100. Adding 101 distinct elements must
+            // tip the estimator out of the direct-count path and into the HLL representation.
+            using var estimator = new ConcurrentCardinalityEstimator(b: 14);
+
+            // Act
+            for (int i = 0; i <= 100; i++)
+            {
+                estimator.Add($"element_{i}");
+            }
+
+            // Assert - the direct-count path is exact up to 100, but past the threshold we are
+            // back to an HLL estimate, so we just verify the count is in a sane range.
+            ulong count = estimator.Count();
+            Assert.InRange(count, 90UL, 110UL);
+            Assert.Equal(101UL, estimator.CountAdditions);
+        }
+
+        [Fact]
+        public void DirectCount_MergeDeduplicates_AndRespectsThreshold()
+        {
+            // Arrange
+            using var a = new ConcurrentCardinalityEstimator(b: 14);
+            using var b = new ConcurrentCardinalityEstimator(b: 14);
+
+            // 30 elements in each, with a 10-element overlap → 50 distinct after merge,
+            // still below the 100-element direct-count threshold.
+            for (int i = 0; i < 30; i++)
+            {
+                a.Add($"a_{i}");
+                b.Add($"a_{i + 20}");
+            }
+
+            // Act
+            a.Merge(b);
+
+            // Assert - merge through the direct-count path must deduplicate exactly.
+            Assert.Equal(50UL, a.Count());
+        }
+
+        [Fact]
+        public void DirectCount_RoundTripsThroughCardinalityEstimator()
+        {
+            // Arrange - convert to the non-concurrent estimator and back, while still in the
+            // direct-count path. The round trip exercises GetStateInternal/InitializeFromState,
+            // both of which had to special-case the bag's duplicate semantics.
+            using var original = new ConcurrentCardinalityEstimator(b: 14);
+            for (int i = 0; i < 25; i++)
+            {
+                original.Add($"value_{i}");
+            }
+
+            // Act
+            CardinalityEstimator snapshot = original.ToCardinalityEstimator();
+            using var roundTripped = new ConcurrentCardinalityEstimator(snapshot);
+
+            // Assert - direct-count is exact, so all three views must report the same count.
+            Assert.Equal(25UL, original.Count());
+            Assert.Equal(25UL, snapshot.Count());
+            Assert.Equal(25UL, roundTripped.Count());
+        }
     }
 }

--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -16,7 +16,8 @@
         <PackageTags>hyperloglog cardinality estimation loglog set c# cardinalityestimation</PackageTags>
         <PackageReleaseNotes>Hardened CardinalityEstimatorSerializer against DoS via maliciously crafted input (validates bitsPerIndex and all length-prefixed counts before allocating)
 Switched target frameworks from net8.0/net9.0 to net8.0/net10.0
-Updated System.IO.Hashing dependency from 8.0.0 to 10.0.7</PackageReleaseNotes>
+Updated System.IO.Hashing dependency from 8.0.0 to 10.0.7
+Fixed ConcurrentCardinalityEstimator direct-count storage: replaced ConcurrentBag&lt;ulong&gt; (which forced O(n) Distinct() on every Add/Count/Merge/Equals) with ConcurrentDictionary used as a concurrent hash set, restoring O(1) operations with no per-call allocations</PackageReleaseNotes>
         <AssemblyVersion>1.15.0.0</AssemblyVersion>
         <FileVersion>1.15.0.0</FileVersion>
         <IncludeSymbols>true</IncludeSymbols>

--- a/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
+++ b/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
@@ -102,9 +102,12 @@ namespace CardinalityEstimation
         private volatile bool isSparse;
 
         /// <summary>
-        /// Set for direct counting of elements (thread-safe)
+        /// Set for direct counting of elements (thread-safe). Used as a concurrent hash set:
+        /// only the keys matter; the byte value is a placeholder. This gives O(1) Add/Contains/Count
+        /// without the per-call allocations and O(n) deduplication that a <see cref="ConcurrentBag{T}"/>
+        /// would require (since a bag permits duplicates).
         /// </summary>
-        private volatile ConcurrentBag<ulong> directCount;
+        private volatile ConcurrentDictionary<ulong, byte> directCount;
 
         /// <summary>
         /// Hash function used
@@ -265,7 +268,11 @@ namespace CardinalityEstimation
             // Init the direct count
             if (state.DirectCount != null)
             {
-                directCount = new ConcurrentBag<ulong>(state.DirectCount);
+                directCount = new ConcurrentDictionary<ulong, byte>();
+                foreach (ulong element in state.DirectCount)
+                {
+                    directCount.TryAdd(element, 0);
+                }
             }
 
             // Init the sparse representation
@@ -290,7 +297,7 @@ namespace CardinalityEstimation
                 // since we are re-initializing the object, we need to reset isSparse to true and sparse lookup
                 isSparse = true;
                 lookupSparse = new ConcurrentDictionary<ushort, byte>();
-                foreach (ulong element in directCount)
+                foreach (ulong element in directCount.Keys)
                 {
                     AddElementHashInternal(element);
                 }
@@ -476,7 +483,7 @@ namespace CardinalityEstimation
                 // If only a few elements have been seen, return the exact count
                 if (directCount != null)
                 {
-                    return (ulong)directCount.Distinct().Count();
+                    return (ulong)directCount.Count;
                 }
 
                 return ComputeCountInternal();
@@ -722,7 +729,7 @@ namespace CardinalityEstimation
             HashSet<ulong> directCountSet = null;
             if (directCount != null)
             {
-                directCountSet = directCount.Distinct().ToHashSet();
+                directCountSet = new HashSet<ulong>(directCount.Keys);
             }
 
             Dictionary<ushort, byte> sparseLookup = null;
@@ -805,10 +812,8 @@ namespace CardinalityEstimation
             
             if (directCount != null)
             {
-                var countBefore = directCount.Distinct().Count();
-                directCount.Add(hashCode);
-                var countAfter = directCount.Distinct().Count();
-                changed = countAfter > countBefore;
+                changed = directCount.TryAdd(hashCode, 0);
+                int countAfter = directCount.Count;
 
                 if (countAfter > DirectCounterMaxElements)
                 {
@@ -816,7 +821,7 @@ namespace CardinalityEstimation
                     try
                     {
                         // Double-check after acquiring write lock
-                        if (directCount != null && directCount.Distinct().Count() > DirectCounterMaxElements)
+                        if (directCount != null && directCount.Count > DirectCounterMaxElements)
                         {
                             directCount = null;
                             changed = true;
@@ -1001,13 +1006,12 @@ namespace CardinalityEstimation
                 // Other instance is using direct counter. If this instance is also using direct counter, merge them.
                 if (directCount != null)
                 {
-                    var otherDistinct = other.directCount.Distinct().ToList();
-                    foreach (var item in otherDistinct)
+                    foreach (var key in other.directCount.Keys)
                     {
-                        directCount.Add(item);
+                        directCount.TryAdd(key, 0);
                     }
-                    
-                    if (directCount.Distinct().Count() > DirectCounterMaxElements)
+
+                    if (directCount.Count > DirectCounterMaxElements)
                     {
                         directCount = null;
                     }
@@ -1138,9 +1142,7 @@ namespace CardinalityEstimation
             }
             if (directCount != null)
             {
-                var thisDistinct = directCount.Distinct().ToHashSet();
-                var otherDistinct = other.directCount.Distinct().ToHashSet();
-                if (thisDistinct.Count != otherDistinct.Count)
+                if (directCount.Count != other.directCount.Count)
                 {
                     return false;
                 }
@@ -1159,11 +1161,12 @@ namespace CardinalityEstimation
 
             if (directCount != null)
             {
-                var thisDistinct = directCount.Distinct().ToHashSet();
-                var otherDistinct = other.directCount.Distinct().ToHashSet();
-                if (!thisDistinct.SetEquals(otherDistinct))
+                foreach (var key in directCount.Keys)
                 {
-                    return false;
+                    if (!other.directCount.ContainsKey(key))
+                    {
+                        return false;
+                    }
                 }
             }
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ These overloads route through a `GetHashCodeSpanDelegate` and avoid the byte-arr
 - Switched target frameworks from `net8.0` / `net9.0` to `net8.0` / `net10.0`.
 - Updated `System.IO.Hashing` dependency from `8.0.0` to `10.0.7`.
 - Hardened `CardinalityEstimatorSerializer` against denial-of-service via a maliciously crafted input stream: `bitsPerIndex` and all length-prefixed counts (direct / sparse / dense) are now validated before any allocation.
+- Fixed `ConcurrentCardinalityEstimator` direct-count storage: replaced the underlying `ConcurrentBag<ulong>` (which permits duplicates and forced an O(n), allocating `Distinct().Count()` on every `Add`, `Count`, `Merge`, and `Equals`) with a `ConcurrentDictionary<ulong, byte>` used as a concurrent hash set. Restores O(1) operations with no per-call allocations on the hot path.
 
 ### 1.14.0
 - Added support for `Span<byte>`, `ReadOnlySpan<byte>`, `Memory<byte>`, and `ReadOnlyMemory<byte>` via `ICardinalityEstimatorMemory` (zero-allocation hot path).


### PR DESCRIPTION
## Issue

ConcurrentCardinalityEstimator.directCount was a `ConcurrentBag<ulong>`, which permits duplicates. Every operation that needed the unique element count had to call `.Distinct().Count()` — allocating a temporary collection and iterating all elements — including:

- `AddElementHashInternal` (called on **every** `Add`) ran `Distinct().Count()` **twice** per call (`countBefore` and `countAfter`), turning what should be an O(1) hash-set probe into an O(n) operation that allocates twice. At the 100-element `DirectCounterMaxElements` threshold this is ~200 LINQ deduplication passes per add.
- `Count()` did `(ulong)directCount.Distinct().Count()` on every call.
- `GetStateInternal`, `EqualsInternal`, and `MergeInternal` all called `.Distinct()` unnecessarily.

## Fix

Replaced `ConcurrentBag<ulong>` with `ConcurrentDictionary<ulong, byte>` used as a concurrent hash set:

- `TryAdd` is O(1) and returns whether the key was new (so we no longer need before/after counts to detect changes).
- `Count` is O(1).
- `ContainsKey` / `Keys` avoid the per-call allocations the bag forced.

All call sites updated: `Count`, `GetStateInternal`, `AddElementHashInternal`, `MergeInternal`, `EqualsInternal`, and the from-state initializer.

## Tests

Added 4 regression tests in `ConcurrentCardinalityEstimatorTests`:

- `DirectCount_ConcurrentDuplicateAdds_DeduplicatesExactly` — 50 distinct values × 200 duplicate adds via `Parallel.For`; Count must be exactly 50. (Would have surfaced any thread-safety regression in the new TryAdd path.)
- `DirectCount_TransitionsToSparse_AtCorrectThreshold` — adding 101 distinct elements must tip out of the direct-count path.
- `DirectCount_MergeDeduplicates_AndRespectsThreshold` — overlapping merges produce exact unique count.
- `DirectCount_RoundTripsThroughCardinalityEstimator` — `ToCardinalityEstimator` round trip preserves the direct-count contents.

Full suite: 134 passed / 1 skipped / 0 failed on both `net8.0` and `net10.0`.

## Other changes

- Added a release-notes bullet under the upcoming `1.15.0` entry in both `CardinalityEstimation.csproj` and `README.md`.
- **No version bump** — this fix accumulates on the `version-1.15` branch.