### PR TITLE
Bump transitive Newtonsoft.Json to 13.0.3 to clear NU1903

### DIFF
--- a/CardinalityEstimation.Test/CardinalityEstimation.Test.csproj
+++ b/CardinalityEstimation.Test/CardinalityEstimation.Test.csproj
@@ -13,6 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Issue

Restore emitted `NU1903`: Newtonsoft.Json 9.0.1 has the high-severity
advisory [GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr).

The vulnerable version was pulled in transitively by
`Microsoft.TestPlatform.ObjectModel 16.8.3` in the test project. The
production `CardinalityEstimation` package does **not** reference
Newtonsoft.Json at all, so end users of the NuGet package are not affected — but the warning was noisy and would block consumers who treat warnings as errors during their own restore.

## Fix

Added a direct `PackageReference` for `Newtonsoft.Json 13.0.3` (latest
stable) to `CardinalityEstimation.Test.csproj`. Direct references take
precedence over transitive ones, so the resolved version is now 13.0.3
and `NU1903` is gone.

## Tests

No production code changed; ran `dotnet test` and got the existing
181 passed / 1 skipped on both `net8.0` and `net10.0`. No new test is
warranted — there is no behavior to regress against, just a package version pin.

## Other changes

- No version bump — accumulates on `version-1.15`.
- No `PackageReleaseNotes` entry — change is test-only and not user-visible.