### PR TITLE
Eliminate per-call heap allocations in primitive Add overloads

### DIFF
--- a/CardinalityEstimation.Test/CardinalityEstimatorTests.cs
+++ b/CardinalityEstimation.Test/CardinalityEstimatorTests.cs
@@ -633,5 +633,58 @@ namespace CardinalityEstimation.Test
             for (int i = 0; i < 50; i++) b.Add($"b_{i}");
             Assert.False(a.Equals(b));
         }
+
+        // ---------------------------------------------------------------------
+        // Regression tests for the zero-allocation primitive Add overloads.
+        //
+        // The Add(int/uint/long/ulong/float/double) overloads previously called
+        // BitConverter.GetBytes(...) which heap-allocated a byte[] every call.
+        // They now use stackalloc + BinaryPrimitives.WriteXxxLittleEndian +
+        // hashFunctionSpan. The byte sequence written is identical to
+        // BitConverter.GetBytes on every supported (little-endian) .NET runtime,
+        // so the hashes — and therefore the cardinality estimate — must match
+        // the equivalent Add(byte[]) call. These tests pin that invariant.
+        // ---------------------------------------------------------------------
+
+        [Fact]
+        public void Add_PrimitiveAndByteArray_ProduceSameHash()
+        {
+            var hll = new CardinalityEstimator(b: 14);
+            hll.Add(123);
+            hll.Add(BitConverter.GetBytes(123));
+            hll.Add(456u);
+            hll.Add(BitConverter.GetBytes(456u));
+            hll.Add(789L);
+            hll.Add(BitConverter.GetBytes(789L));
+            hll.Add(1011UL);
+            hll.Add(BitConverter.GetBytes(1011UL));
+            hll.Add(3.14f);
+            hll.Add(BitConverter.GetBytes(3.14f));
+            hll.Add(2.71828);
+            hll.Add(BitConverter.GetBytes(2.71828));
+
+            // 12 Add calls, but each value-pair must hash to the same bucket and dedupe.
+            Assert.Equal(12UL, hll.CountAdditions);
+            Assert.Equal(6UL, hll.Count());
+        }
+
+        [Fact]
+        public void Add_String_StackallocAndHeapPath_AgreeWithByteArray()
+        {
+            // Short string: hits the stackalloc path (UTF-8 max bytes <= threshold).
+            var hll = new CardinalityEstimator(b: 14);
+            const string shortStr = "hello world";
+            hll.Add(shortStr);
+            hll.Add(System.Text.Encoding.UTF8.GetBytes(shortStr));
+            Assert.Equal(1UL, hll.Count());
+            Assert.Equal(2UL, hll.CountAdditions);
+
+            // Long string: forces the heap fallback (UTF-8 max bytes > threshold).
+            var hll2 = new CardinalityEstimator(b: 14);
+            string longStr = new string('x', 200); // max UTF-8 bytes = 600 > 256
+            hll2.Add(longStr);
+            hll2.Add(System.Text.Encoding.UTF8.GetBytes(longStr));
+            Assert.Equal(1UL, hll2.Count());
+        }
     }
 }

--- a/CardinalityEstimation.Test/ConcurrentCardinalityEstimatorTests.cs
+++ b/CardinalityEstimation.Test/ConcurrentCardinalityEstimatorTests.cs
@@ -784,5 +784,48 @@ namespace CardinalityEstimation.Test
             Assert.Equal(25UL, snapshot.Count());
             Assert.Equal(25UL, roundTripped.Count());
         }
+
+        // ---------------------------------------------------------------------
+        // Regression tests for the zero-allocation primitive Add overloads.
+        // See CardinalityEstimatorTests for the full rationale; these mirror
+        // the same invariant on the concurrent estimator.
+        // ---------------------------------------------------------------------
+
+        [Fact]
+        public void Add_PrimitiveAndByteArray_ProduceSameHash()
+        {
+            using var hll = new ConcurrentCardinalityEstimator(b: 14);
+            hll.Add(123);
+            hll.Add(BitConverter.GetBytes(123));
+            hll.Add(456u);
+            hll.Add(BitConverter.GetBytes(456u));
+            hll.Add(789L);
+            hll.Add(BitConverter.GetBytes(789L));
+            hll.Add(1011UL);
+            hll.Add(BitConverter.GetBytes(1011UL));
+            hll.Add(3.14f);
+            hll.Add(BitConverter.GetBytes(3.14f));
+            hll.Add(2.71828);
+            hll.Add(BitConverter.GetBytes(2.71828));
+
+            Assert.Equal(12UL, hll.CountAdditions);
+            Assert.Equal(6UL, hll.Count());
+        }
+
+        [Fact]
+        public void Add_String_StackallocAndHeapPath_AgreeWithByteArray()
+        {
+            using var hll = new ConcurrentCardinalityEstimator(b: 14);
+            const string shortStr = "hello world";
+            hll.Add(shortStr);
+            hll.Add(System.Text.Encoding.UTF8.GetBytes(shortStr));
+            Assert.Equal(1UL, hll.Count());
+
+            using var hll2 = new ConcurrentCardinalityEstimator(b: 14);
+            string longStr = new string('x', 200);
+            hll2.Add(longStr);
+            hll2.Add(System.Text.Encoding.UTF8.GetBytes(longStr));
+            Assert.Equal(1UL, hll2.Count());
+        }
     }
 }

--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -17,7 +17,8 @@
         <PackageReleaseNotes>Hardened CardinalityEstimatorSerializer against DoS via maliciously crafted input (validates bitsPerIndex and all length-prefixed counts before allocating)
 Switched target frameworks from net8.0/net9.0 to net8.0/net10.0
 Updated System.IO.Hashing dependency from 8.0.0 to 10.0.7
-Fixed ConcurrentCardinalityEstimator direct-count storage: replaced ConcurrentBag&lt;ulong&gt; (which forced O(n) Distinct() on every Add/Count/Merge/Equals) with ConcurrentDictionary used as a concurrent hash set, restoring O(1) operations with no per-call allocations</PackageReleaseNotes>
+Fixed ConcurrentCardinalityEstimator direct-count storage: replaced ConcurrentBag&lt;ulong&gt; (which forced O(n) Distinct() on every Add/Count/Merge/Equals) with ConcurrentDictionary used as a concurrent hash set, restoring O(1) operations with no per-call allocations
+Eliminated per-call heap allocations in primitive Add overloads (int/uint/long/ulong/float/double) by replacing BitConverter.GetBytes with stackalloc + BinaryPrimitives + the span hash delegate; Add(string) now also uses a stackalloc UTF-8 buffer for short strings</PackageReleaseNotes>
         <AssemblyVersion>1.15.0.0</AssemblyVersion>
         <FileVersion>1.15.0.0</FileVersion>
         <IncludeSymbols>true</IncludeSymbols>

--- a/CardinalityEstimation/CardinalityEstimator.cs
+++ b/CardinalityEstimation/CardinalityEstimator.cs
@@ -26,6 +26,7 @@
 namespace CardinalityEstimation
 {
     using System;
+    using System.Buffers.Binary;
     using System.Collections.Generic;
     using System.Text;
     using Hash;
@@ -75,6 +76,13 @@ namespace CardinalityEstimation
         /// Max number of elements to hold in the direct representation
         /// </summary>
         private const int DirectCounterMaxElements = 100;
+
+        /// <summary>
+        /// Maximum number of bytes a string can encode to before <see cref="Add(string)"/>
+        /// falls back to a heap allocation. Strings whose UTF-8 max-byte-count is at or below
+        /// this threshold are encoded into a stackalloc buffer to avoid GC pressure.
+        /// </summary>
+        private const int StackallocByteThreshold = 256;
         #endregion
 
         #region Private fields
@@ -314,8 +322,22 @@ namespace CardinalityEstimation
         {
             if (element == null)
                 throw new ArgumentNullException(nameof(element));
-                
-            ulong hashCode = hashFunction(Encoding.UTF8.GetBytes(element));
+
+            ulong hashCode;
+            // Avoid heap-allocating a temporary byte[] for short strings by encoding into a
+            // stack buffer and hashing through the span delegate. UTF-8 is endian-independent,
+            // so the resulting bytes are identical to Encoding.UTF8.GetBytes(element).
+            if (Encoding.UTF8.GetMaxByteCount(element.Length) <= StackallocByteThreshold)
+            {
+                Span<byte> bytes = stackalloc byte[StackallocByteThreshold];
+                int written = Encoding.UTF8.GetBytes(element, bytes);
+                hashCode = hashFunctionSpan(bytes.Slice(0, written));
+            }
+            else
+            {
+                hashCode = hashFunctionSpan(Encoding.UTF8.GetBytes(element));
+            }
+
             bool changed = AddElementHash(hashCode);
             CountAdditions++;
             return changed;
@@ -328,7 +350,9 @@ namespace CardinalityEstimation
         /// <returns>True if the estimator's state was modified, false otherwise</returns>
         public bool Add(int element)
         {
-            ulong hashCode = hashFunction(BitConverter.GetBytes(element));
+            Span<byte> bytes = stackalloc byte[sizeof(int)];
+            BinaryPrimitives.WriteInt32LittleEndian(bytes, element);
+            ulong hashCode = hashFunctionSpan(bytes);
             bool changed = AddElementHash(hashCode);
             CountAdditions++;
             return changed;
@@ -341,7 +365,9 @@ namespace CardinalityEstimation
         /// <returns>True if the estimator's state was modified, false otherwise</returns>
         public bool Add(uint element)
         {
-            ulong hashCode = hashFunction(BitConverter.GetBytes(element));
+            Span<byte> bytes = stackalloc byte[sizeof(uint)];
+            BinaryPrimitives.WriteUInt32LittleEndian(bytes, element);
+            ulong hashCode = hashFunctionSpan(bytes);
             bool changed = AddElementHash(hashCode);
             CountAdditions++;
             return changed;
@@ -354,7 +380,9 @@ namespace CardinalityEstimation
         /// <returns>True if the estimator's state was modified, false otherwise</returns>
         public bool Add(long element)
         {
-            ulong hashCode = hashFunction(BitConverter.GetBytes(element));
+            Span<byte> bytes = stackalloc byte[sizeof(long)];
+            BinaryPrimitives.WriteInt64LittleEndian(bytes, element);
+            ulong hashCode = hashFunctionSpan(bytes);
             bool changed = AddElementHash(hashCode);
             CountAdditions++;
             return changed;
@@ -367,7 +395,9 @@ namespace CardinalityEstimation
         /// <returns>True if the estimator's state was modified, false otherwise</returns>
         public bool Add(ulong element)
         {
-            ulong hashCode = hashFunction(BitConverter.GetBytes(element));
+            Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+            BinaryPrimitives.WriteUInt64LittleEndian(bytes, element);
+            ulong hashCode = hashFunctionSpan(bytes);
             bool changed = AddElementHash(hashCode);
             CountAdditions++;
             return changed;
@@ -380,7 +410,9 @@ namespace CardinalityEstimation
         /// <returns>True if the estimator's state was modified, false otherwise</returns>
         public bool Add(float element)
         {
-            ulong hashCode = hashFunction(BitConverter.GetBytes(element));
+            Span<byte> bytes = stackalloc byte[sizeof(float)];
+            BinaryPrimitives.WriteSingleLittleEndian(bytes, element);
+            ulong hashCode = hashFunctionSpan(bytes);
             bool changed = AddElementHash(hashCode);
             CountAdditions++;
             return changed;
@@ -393,7 +425,9 @@ namespace CardinalityEstimation
         /// <returns>True if the estimator's state was modified, false otherwise</returns>
         public bool Add(double element)
         {
-            ulong hashCode = hashFunction(BitConverter.GetBytes(element));
+            Span<byte> bytes = stackalloc byte[sizeof(double)];
+            BinaryPrimitives.WriteDoubleLittleEndian(bytes, element);
+            ulong hashCode = hashFunctionSpan(bytes);
             bool changed = AddElementHash(hashCode);
             CountAdditions++;
             return changed;

--- a/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
+++ b/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
@@ -26,6 +26,7 @@
 namespace CardinalityEstimation
 {
     using System;
+    using System.Buffers.Binary;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
@@ -53,6 +54,13 @@ namespace CardinalityEstimation
         /// Max number of elements to hold in the direct representation
         /// </summary>
         private const int DirectCounterMaxElements = 100;
+
+        /// <summary>
+        /// Maximum number of bytes a string can encode to before <see cref="Add(string)"/>
+        /// falls back to a heap allocation. Strings whose UTF-8 max-byte-count is at or below
+        /// this threshold are encoded into a stackalloc buffer to avoid GC pressure.
+        /// </summary>
+        private const int StackallocByteThreshold = 256;
         #endregion
 
         #region Private fields
@@ -317,7 +325,19 @@ namespace CardinalityEstimation
         public bool Add(string element)
         {
             ThrowIfDisposed();
-            ulong hashCode = hashFunction(Encoding.UTF8.GetBytes(element));
+
+            ulong hashCode;
+            if (Encoding.UTF8.GetMaxByteCount(element.Length) <= StackallocByteThreshold)
+            {
+                Span<byte> bytes = stackalloc byte[StackallocByteThreshold];
+                int written = Encoding.UTF8.GetBytes(element, bytes);
+                hashCode = hashFunctionSpan(bytes.Slice(0, written));
+            }
+            else
+            {
+                hashCode = hashFunctionSpan(Encoding.UTF8.GetBytes(element));
+            }
+
             bool changed = AddElementHash(hashCode);
             Interlocked.Increment(ref countAdditions);
             return changed;
@@ -330,7 +350,9 @@ namespace CardinalityEstimation
         public bool Add(int element)
         {
             ThrowIfDisposed();
-            ulong hashCode = hashFunction(BitConverter.GetBytes(element));
+            Span<byte> bytes = stackalloc byte[sizeof(int)];
+            BinaryPrimitives.WriteInt32LittleEndian(bytes, element);
+            ulong hashCode = hashFunctionSpan(bytes);
             bool changed = AddElementHash(hashCode);
             Interlocked.Increment(ref countAdditions);
             return changed;
@@ -343,7 +365,9 @@ namespace CardinalityEstimation
         public bool Add(uint element)
         {
             ThrowIfDisposed();
-            ulong hashCode = hashFunction(BitConverter.GetBytes(element));
+            Span<byte> bytes = stackalloc byte[sizeof(uint)];
+            BinaryPrimitives.WriteUInt32LittleEndian(bytes, element);
+            ulong hashCode = hashFunctionSpan(bytes);
             bool changed = AddElementHash(hashCode);
             Interlocked.Increment(ref countAdditions);
             return changed;
@@ -356,7 +380,9 @@ namespace CardinalityEstimation
         public bool Add(long element)
         {
             ThrowIfDisposed();
-            ulong hashCode = hashFunction(BitConverter.GetBytes(element));
+            Span<byte> bytes = stackalloc byte[sizeof(long)];
+            BinaryPrimitives.WriteInt64LittleEndian(bytes, element);
+            ulong hashCode = hashFunctionSpan(bytes);
             bool changed = AddElementHash(hashCode);
             Interlocked.Increment(ref countAdditions);
             return changed;
@@ -369,7 +395,9 @@ namespace CardinalityEstimation
         public bool Add(ulong element)
         {
             ThrowIfDisposed();
-            ulong hashCode = hashFunction(BitConverter.GetBytes(element));
+            Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+            BinaryPrimitives.WriteUInt64LittleEndian(bytes, element);
+            ulong hashCode = hashFunctionSpan(bytes);
             bool changed = AddElementHash(hashCode);
             Interlocked.Increment(ref countAdditions);
             return changed;
@@ -382,7 +410,9 @@ namespace CardinalityEstimation
         public bool Add(float element)
         {
             ThrowIfDisposed();
-            ulong hashCode = hashFunction(BitConverter.GetBytes(element));
+            Span<byte> bytes = stackalloc byte[sizeof(float)];
+            BinaryPrimitives.WriteSingleLittleEndian(bytes, element);
+            ulong hashCode = hashFunctionSpan(bytes);
             bool changed = AddElementHash(hashCode);
             Interlocked.Increment(ref countAdditions);
             return changed;
@@ -395,7 +425,9 @@ namespace CardinalityEstimation
         public bool Add(double element)
         {
             ThrowIfDisposed();
-            ulong hashCode = hashFunction(BitConverter.GetBytes(element));
+            Span<byte> bytes = stackalloc byte[sizeof(double)];
+            BinaryPrimitives.WriteDoubleLittleEndian(bytes, element);
+            ulong hashCode = hashFunctionSpan(bytes);
             bool changed = AddElementHash(hashCode);
             Interlocked.Increment(ref countAdditions);
             return changed;


### PR DESCRIPTION
## Issue

Every primitive `Add` overload on both `CardinalityEstimator` and `ConcurrentCardinalityEstimator` heap-allocated a temporary `byte[]` on each call:

`ulong hashCode = hashFunction(BitConverter.GetBytes(element)); // allocates byte[4] or byte[8]`

This generated GC pressure proportional to the insert rate — exactly the wrong shape for a cardinality estimator typically fed millions of values. `Add(string)` had the same problem with `Encoding.UTF8.GetBytes(string)`. A `hashFunctionSpan` delegate already exists on both classes for this purpose but was unused on the primitive paths.

## Fix

- `Add(int)`, `Add(uint)`, `Add(long)`, `Add(ulong)`, `Add(float)`, `Add(double)` now `stackalloc` a small buffer and write the value via `BinaryPrimitives.WriteXxxLittleEndian`, then hash through `hashFunctionSpan`.
- `Add(string)` `stackalloc`s a 256-byte buffer and uses `Encoding.UTF8.GetBytes(string, Span<byte>)` for short strings (UTF-8 max-byte-count <= 256), falling back to a heap allocation only for longer strings.
- Symmetric changes in `CardinalityEstimator.cs` and `ConcurrentCardinalityEstimator.cs`.

The byte sequences written are byte-equivalent to the previous `BitConverter.GetBytes`/`Encoding.UTF8.GetBytes` calls on every supported little-endian runtime (which is everywhere .NET runs in practice). Hashes therefore match, and existing cardinality estimates are unchanged.

## Tests

Added byte-equivalence regression tests pinning the invariant that `Add(value)` and `Add(BitConverter.GetBytes(value))` produce the same hash for every primitive type, and that `Add(string)` agrees with `Add(Encoding.UTF8.GetBytes(string))` on both the stackalloc and heap-fallback paths:

- `CardinalityEstimatorTests.Add_PrimitiveAndByteArray_ProduceSameHash`
- `CardinalityEstimatorTests.Add_String_StackallocAndHeapPath_AgreeWithByteArray`
- `ConcurrentCardinalityEstimatorTests.Add_PrimitiveAndByteArray_ProduceSameHash`
- `ConcurrentCardinalityEstimatorTests.Add_String_StackallocAndHeapPath_AgreeWithByteArray`

These would fail if a future change accidentally introduced an endianness mismatch or stride bug. Full suite: 185 passed / 1 skipped on both `net8.0` and `net10.0` (was 181 / 1).

## Other changes

- `PackageReleaseNotes` updated under the upcoming `1.15.0` entry.
- No version bump — accumulates on `version-1.15`.