### PR TITLE
Precompute inverse-powers-of-two lookup table for Count()

### DIFF
--- a/CardinalityEstimation.Test/CardinalityEstimatorTests.cs
+++ b/CardinalityEstimation.Test/CardinalityEstimatorTests.cs
@@ -635,6 +635,39 @@ namespace CardinalityEstimation.Test
         }
 
         // ---------------------------------------------------------------------
+        // Regression tests for the precomputed InversePowersOfTwo lookup table.
+        //
+        // Count() previously called Math.Pow(2, -sigma) up to m = 2^bitsPerIndex
+        // times per call (up to 65,536 transcendental calls for b=16). It now
+        // indexes into a precomputed table. Each table entry MUST be bit-equivalent
+        // to Math.Pow(2.0, -i) so that Count() produces the exact same double as
+        // before. These tests pin that invariant.
+        // ---------------------------------------------------------------------
+
+        [Fact]
+        public void InversePowersOfTwo_TableMatchesMathPowExactly()
+        {
+            Assert.Equal(65, HllConstants.InversePowersOfTwo.Length);
+            for (int i = 0; i < HllConstants.InversePowersOfTwo.Length; i++)
+            {
+                Assert.Equal(Math.Pow(2.0, -i), HllConstants.InversePowersOfTwo[i]);
+            }
+        }
+
+        [Fact]
+        public void InversePowersOfTwo_MaxSigmaIndexIsValidForAllBitsPerIndex()
+        {
+            // sigma is bounded by bitsForHll + 1 = (64 - bitsPerIndex) + 1.
+            // For the smallest supported bitsPerIndex (4), max sigma = 61, well under 65.
+            for (int b = 4; b <= 16; b++)
+            {
+                int maxSigma = (64 - b) + 1;
+                Assert.True(maxSigma < HllConstants.InversePowersOfTwo.Length,
+                    $"max sigma {maxSigma} for b={b} must be a valid index into InversePowersOfTwo");
+            }
+        }
+
+        // ---------------------------------------------------------------------
         // Regression tests for the zero-allocation primitive Add overloads.
         //
         // The Add(int/uint/long/ulong/float/double) overloads previously called

--- a/CardinalityEstimation.Test/ConcurrentCardinalityEstimatorTests.cs
+++ b/CardinalityEstimation.Test/ConcurrentCardinalityEstimatorTests.cs
@@ -827,5 +827,11 @@ namespace CardinalityEstimation.Test
             hll2.Add(System.Text.Encoding.UTF8.GetBytes(longStr));
             Assert.Equal(1UL, hll2.Count());
         }
+
+        // ---------------------------------------------------------------------
+        // The shared HllConstants.InversePowersOfTwo table is exercised by the
+        // unit test in CardinalityEstimatorTests; both estimators now consume
+        // the same table so a single regression test is sufficient.
+        // ---------------------------------------------------------------------
     }
 }

--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -18,7 +18,8 @@
 Switched target frameworks from net8.0/net9.0 to net8.0/net10.0
 Updated System.IO.Hashing dependency from 8.0.0 to 10.0.7
 Fixed ConcurrentCardinalityEstimator direct-count storage: replaced ConcurrentBag&lt;ulong&gt; (which forced O(n) Distinct() on every Add/Count/Merge/Equals) with ConcurrentDictionary used as a concurrent hash set, restoring O(1) operations with no per-call allocations
-Eliminated per-call heap allocations in primitive Add overloads (int/uint/long/ulong/float/double) by replacing BitConverter.GetBytes with stackalloc + BinaryPrimitives + the span hash delegate; Add(string) now also uses a stackalloc UTF-8 buffer for short strings</PackageReleaseNotes>
+Eliminated per-call heap allocations in primitive Add overloads (int/uint/long/ulong/float/double) by replacing BitConverter.GetBytes with stackalloc + BinaryPrimitives + the span hash delegate; Add(string) now also uses a stackalloc UTF-8 buffer for short strings
+Replaced per-bucket Math.Pow(2, -sigma) calls in Count() with a precomputed lookup table shared by both estimators (bit-equivalent results, removes a transcendental call from a loop that runs up to 65,536 times per Count())</PackageReleaseNotes>
         <AssemblyVersion>1.15.0.0</AssemblyVersion>
         <FileVersion>1.15.0.0</FileVersion>
         <IncludeSymbols>true</IncludeSymbols>

--- a/CardinalityEstimation/CardinalityEstimator.cs
+++ b/CardinalityEstimation/CardinalityEstimator.cs
@@ -1,4 +1,4 @@
-﻿// /*  
+// /*  
 //     See https://github.com/saguiitay/CardinalityEstimation.
 //     The MIT License (MIT)
 // 
@@ -83,6 +83,7 @@ namespace CardinalityEstimation
         /// this threshold are encoded into a stackalloc buffer to avoid GC pressure.
         /// </summary>
         private const int StackallocByteThreshold = 256;
+
         #endregion
 
         #region Private fields
@@ -531,7 +532,7 @@ namespace CardinalityEstimation
                 foreach (KeyValuePair<ushort, byte> kvp in lookupSparse)
                 {
                     byte sigma = kvp.Value;
-                    zInverse += Math.Pow(2, -sigma);
+                    zInverse += HllConstants.InversePowersOfTwo[sigma];
                 }
                 v = m - lookupSparse.Count;
                 zInverse += m - lookupSparse.Count;
@@ -542,7 +543,7 @@ namespace CardinalityEstimation
                 for (var i = 0; i < m; i++)
                 {
                     byte sigma = lookupDense[i];
-                    zInverse += Math.Pow(2, -sigma);
+                    zInverse += HllConstants.InversePowersOfTwo[sigma];
                     if (sigma == 0)
                     {
                         v++;

--- a/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
+++ b/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
@@ -940,7 +940,7 @@ namespace CardinalityEstimation
                 foreach (KeyValuePair<ushort, byte> kvp in lookupSparse)
                 {
                     byte sigma = kvp.Value;
-                    zInverse += Math.Pow(2, -sigma);
+                    zInverse += HllConstants.InversePowersOfTwo[sigma];
                 }
                 v = m - lookupSparse.Count;
                 zInverse += m - lookupSparse.Count;
@@ -951,7 +951,7 @@ namespace CardinalityEstimation
                 for (var i = 0; i < m; i++)
                 {
                     byte sigma = lookupDense[i];
-                    zInverse += Math.Pow(2, -sigma);
+                    zInverse += HllConstants.InversePowersOfTwo[sigma];
                     if (sigma == 0)
                     {
                         v++;

--- a/CardinalityEstimation/HllConstants.cs
+++ b/CardinalityEstimation/HllConstants.cs
@@ -1,0 +1,66 @@
+﻿// /*  
+//     See https://github.com/saguiitay/CardinalityEstimation.
+//     The MIT License (MIT)
+// 
+//     Copyright (c) 2015 Microsoft
+// 
+//     Permission is hereby granted, free of charge, to any person obtaining a copy
+//     of this software and associated documentation files (the "Software"), to deal
+//     in the Software without restriction, including without limitation the rights
+//     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//     copies of the Software, and to permit persons to whom the Software is
+//     furnished to do so, subject to the following conditions:
+// 
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+// 
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//     SOFTWARE.
+// */
+
+namespace CardinalityEstimation
+{
+    using System;
+
+    /// <summary>
+    /// Shared compile-time/static constants and lookup tables used by both
+    /// <see cref="CardinalityEstimator"/> and <see cref="ConcurrentCardinalityEstimator"/>.
+    /// </summary>
+    internal static class HllConstants
+    {
+        /// <summary>
+        /// Length of <see cref="InversePowersOfTwo"/>. sigma is bounded by
+        /// bitsForHll + 1 = (64 - bitsPerIndex) + 1, which is at most 61 for the
+        /// supported range of bitsPerIndex (4..16). The table is sized 65 to safely
+        /// cover all sigma values without a bounds check ever firing on real inputs.
+        /// </summary>
+        internal const int InversePowersOfTwoLength = 65;
+
+        /// <summary>
+        /// Precomputed table of 2^-i for i in [0, <see cref="InversePowersOfTwoLength"/>),
+        /// used by the HLL summation in <c>Count()</c> to evaluate each bucket in O(1)
+        /// instead of calling <see cref="Math.Pow(double, double)"/> (a transcendental
+        /// function) up to 2^16 times per call.
+        /// </summary>
+        /// <remarks>
+        /// Each entry is bit-equivalent to <c>Math.Pow(2.0, -i)</c> because every 2^-i
+        /// for i in [0, 64] is exactly representable as an IEEE 754 double.
+        /// </remarks>
+        internal static readonly double[] InversePowersOfTwo = BuildInversePowersOfTwo();
+
+        private static double[] BuildInversePowersOfTwo()
+        {
+            var table = new double[InversePowersOfTwoLength];
+            for (int i = 0; i < table.Length; i++)
+            {
+                table[i] = Math.Pow(2.0, -i);
+            }
+            return table;
+        }
+    }
+}


### PR DESCRIPTION
## Issue

`Math.Pow(2, -sigma)` was called inside the HLL summation loop in both `CardinalityEstimator.Count()` and `ConcurrentCardinalityEstimator.ComputeCountInternal()`, executing a transcendental function once per bucket -- up to `m = 2^bitsPerIndex = 65,536` times per `Count()` invocation for the largest supported `b=16`.

Since `sigma` is a bounded byte (at most `bitsForHll + 1 <= 61`) and `2^-sigma` for those values is exactly representable as an IEEE 754 double, this is a pure waste.

## Fix

Introduced a new `internal static class HllConstants` that owns a single precomputed `double[] InversePowersOfTwo` of length 65 (`InversePowersOfTwo[i] = Math.Pow(2.0, -i)`). Both `CardinalityEstimator` and `ConcurrentCardinalityEstimator` now read `HllConstants.InversePowersOfTwo[sigma]` in their hot loops instead of calling `Math.Pow`.

Results are **bit-equivalent** to the previous output (each `2^-i` for `i` in [0, 64] is exactly representable as a double), so all existing accuracy and serialization tests pass unchanged.

## Tests

Added two regression tests in `CardinalityEstimatorTests.cs`:

- `InversePowersOfTwo_TableMatchesMathPowExactly` -- pins each table entry against `Math.Pow(2.0, -i)` for `i` in [0, 64]. Fails immediately if anyone changes the table generator in a non-bit-equivalent way.
- `InversePowersOfTwo_MaxSigmaIndexIsValidForAllBitsPerIndex` -- proves the table is large enough for every supported `bitsPerIndex` (4..16), so the indexed read never throws on real inputs.

Full suite: **187 passed, 1 skipped, 0 failed** on both `net8.0` and `net10.0`.

## Other changes

- Added a release-notes bullet under the upcoming 1.15.0 entry in `CardinalityEstimation.csproj`.
- **No version bump** -- accumulates on `version-1.15`.