### PR TITLE
Bulk-write dense lookup array in serializer

### DIFF
--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -19,7 +19,8 @@ Switched target frameworks from net8.0/net9.0 to net8.0/net10.0
 Updated System.IO.Hashing dependency from 8.0.0 to 10.0.7
 Fixed ConcurrentCardinalityEstimator direct-count storage: replaced ConcurrentBag&lt;ulong&gt; (which forced O(n) Distinct() on every Add/Count/Merge/Equals) with ConcurrentDictionary used as a concurrent hash set, restoring O(1) operations with no per-call allocations
 Eliminated per-call heap allocations in primitive Add overloads (int/uint/long/ulong/float/double) by replacing BitConverter.GetBytes with stackalloc + BinaryPrimitives + the span hash delegate; Add(string) now also uses a stackalloc UTF-8 buffer for short strings
-Replaced per-bucket Math.Pow(2, -sigma) calls in Count() with a precomputed lookup table shared by both estimators (bit-equivalent results, removes a transcendental call from a loop that runs up to 65,536 times per Count())</PackageReleaseNotes>
+Replaced per-bucket Math.Pow(2, -sigma) calls in Count() with a precomputed lookup table shared by both estimators (bit-equivalent results, removes a transcendental call from a loop that runs up to 65,536 times per Count())
+Serializer now writes the dense lookup array (up to 65,536 bytes) in a single bulk BinaryWriter.Write(byte[]) call instead of one BinaryWriter.Write(byte) per element (byte-identical output)</PackageReleaseNotes>
         <AssemblyVersion>1.15.0.0</AssemblyVersion>
         <FileVersion>1.15.0.0</FileVersion>
         <IncludeSymbols>true</IncludeSymbols>

--- a/CardinalityEstimation/CardinalityEstimatorSerializer.cs
+++ b/CardinalityEstimation/CardinalityEstimatorSerializer.cs
@@ -157,10 +157,7 @@ namespace CardinalityEstimation
             else
             {
                 writer.Write(data.LookupDense.Length);
-                foreach (byte element in data.LookupDense)
-                {
-                    writer.Write(element);
-                }
+                writer.Write(data.LookupDense);
             }
 
             writer.Write(data.CountAdditions);


### PR DESCRIPTION
## Issue

`CardinalityEstimatorSerializer.Write()` serialized the dense lookup (up to `m = 2^bitsPerIndex = 65,536` bytes for `b=16`) one byte at a time:

```csharp
foreach (byte element in data.LookupDense)
{
    writer.Write(element); // up to 65,536 individual BinaryWriter calls
}
```

## Fix

Replaced the loop with a single `BinaryWriter.Write(byte[])` bulk-copy call:

```csharp
writer.Write(data.LookupDense);
```

On-the-wire output is **byte-identical** -- `BinaryWriter.Write(byte)` and `BinaryWriter.Write(byte[])` both emit raw bytes with no length prefix or framing.

## Tests

No new test required: the change is observably a no-op on the serialized stream, and the existing suite already pins both the byte layout and the read path:

- `TestSerializerCardinality100000` asserts the exact serialized size (`Assert.Equal(21 + data.LookupDense.Length, results.Length)`) -- would fail if the dense-write path emitted a different number of bytes.
- `SerializerCanDeserializeVersion2Point1` deserializes a stored dense fixture -- pins backward compatibility with previously-written streams.
- `TestSerializerMultipleCardinalityAndBitsCombinations` roundtrips dense estimators across the full range of `bitsPerIndex`.

Full suite: **187 passed, 1 skipped, 0 failed** on both `net8.0` and `net10.0`.

## Other changes

- Added a release-notes bullet under the upcoming 1.15.0 entry in `CardinalityEstimation.csproj`.
- **No version bump** -- accumulates on `version-1.15`.