### PR TITLE
Simplify 1.15.0 release notes to short phrases

### DIFF
--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -14,12 +14,13 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <Copyright>Copyright © Sagui Itay 2022</Copyright>
         <PackageTags>hyperloglog cardinality estimation loglog set c# cardinalityestimation</PackageTags>
-        <PackageReleaseNotes>Hardened CardinalityEstimatorSerializer against DoS via maliciously crafted input (validates bitsPerIndex and all length-prefixed counts before allocating)
-Switched target frameworks from net8.0/net9.0 to net8.0/net10.0
-Updated System.IO.Hashing dependency from 8.0.0 to 10.0.7
-Fixed ConcurrentCardinalityEstimator direct-count storage: replaced ConcurrentBag&lt;ulong&gt; (which forced O(n) Distinct() on every Add/Count/Merge/Equals) with ConcurrentDictionary used as a concurrent hash set, restoring O(1) operations with no per-call allocations
-Eliminated per-call heap allocations in primitive Add overloads (int/uint/long/ulong/float/double) by replacing BitConverter.GetBytes with stackalloc + BinaryPrimitives + the span hash delegate; Add(string) now also uses a stackalloc UTF-8 buffer for short strings
-Replaced per-bucket Math.Pow(2, -sigma) calls in Count() with a precomputed lookup table shared by both estimators (bit-equivalent results, removes a transcendental call from a loop that runs up to 65,536 times per Count())</PackageReleaseNotes>
+        <PackageReleaseNotes>Hardened CardinalityEstimatorSerializer against DoS via crafted input
+Switched target frameworks to net8.0/net10.0
+Updated System.IO.Hashing to 10.0.7
+Fixed O(n) ConcurrentCardinalityEstimator direct-count storage (ConcurrentBag -&gt; ConcurrentDictionary)
+Zero-allocation primitive Add overloads (stackalloc + span hash)
+Precomputed inverse-powers-of-two table in Count() (removes Math.Pow from hot loop)
+Bulk-write dense lookup array in serializer</PackageReleaseNotes>
         <AssemblyVersion>1.15.0.0</AssemblyVersion>
         <FileVersion>1.15.0.0</FileVersion>
         <IncludeSymbols>true</IncludeSymbols>

--- a/README.md
+++ b/README.md
@@ -158,10 +158,13 @@ These overloads route through a `GetHashCodeSpanDelegate` and avoid the byte-arr
 ## Release Notes
 
 ### 1.15.0
-- Switched target frameworks from `net8.0` / `net9.0` to `net8.0` / `net10.0`.
-- Updated `System.IO.Hashing` dependency from `8.0.0` to `10.0.7`.
-- Hardened `CardinalityEstimatorSerializer` against denial-of-service via a maliciously crafted input stream: `bitsPerIndex` and all length-prefixed counts (direct / sparse / dense) are now validated before any allocation.
-- Fixed `ConcurrentCardinalityEstimator` direct-count storage: replaced the underlying `ConcurrentBag<ulong>` (which permits duplicates and forced an O(n), allocating `Distinct().Count()` on every `Add`, `Count`, `Merge`, and `Equals`) with a `ConcurrentDictionary<ulong, byte>` used as a concurrent hash set. Restores O(1) operations with no per-call allocations on the hot path.
+- Hardened `CardinalityEstimatorSerializer` against DoS via crafted input.
+- Switched target frameworks to `net8.0` / `net10.0`.
+- Updated `System.IO.Hashing` to `10.0.7`.
+- Fixed O(n) `ConcurrentCardinalityEstimator` direct-count storage (`ConcurrentBag` → `ConcurrentDictionary`).
+- Zero-allocation primitive `Add` overloads (`stackalloc` + span hash).
+- Precomputed inverse-powers-of-two table in `Count()` (removes `Math.Pow` from hot loop).
+- Bulk-write dense lookup array in serializer.
 
 ### 1.14.0
 - Added support for `Span<byte>`, `ReadOnlySpan<byte>`, `Memory<byte>`, and `ReadOnlyMemory<byte>` via `ICardinalityEstimatorMemory` (zero-allocation hot path).


### PR DESCRIPTION
## Issue

The 1.15.0 release notes (in both `CardinalityEstimation.csproj` `PackageReleaseNotes` and the `Release Notes` section of `README.md`) were verbose multi-line entries explaining the implementation detail of each change. They are hard to scan on NuGet and in the README.

## Fix

Condensed each bullet to a short phrase. README and `PackageReleaseNotes` are now in sync and cover all six 1.15.0 changes (the README was previously missing the three perf bullets added later).

## Tests

Docs-only change; no code paths affected. `dotnet build` confirms the csproj still parses cleanly.

## Other changes

- **No version bump** -- accumulates on `version-1.15`.