### PR TITLE
Fix Merge(IEnumerable) double-count and copy ctor losing CountAdditions

### DIFF
--- a/CardinalityEstimation.Test/CardinalityEstimatorTests.cs
+++ b/CardinalityEstimation.Test/CardinalityEstimatorTests.cs
@@ -233,6 +233,52 @@ namespace CardinalityEstimation.Test
             Assert.Equal(expectedBitsPerIndex, result.GetState().BitsPerIndex);
         }
 
+        /// <summary>
+        /// Regression: <see cref="CardinalityEstimator.Merge(System.Collections.Generic.IEnumerable{CardinalityEstimator})"/>
+        /// previously initialized <c>result</c> from the first non-null estimator and then immediately
+        /// merged the same estimator into <c>result</c>, double-counting <see cref="CardinalityEstimator.CountAdditions"/>
+        /// for the seed element. (Was masked by a separate bug in the copy constructor that did not copy CountAdditions.)
+        /// CountAdditions on the merged result must equal the sum of CountAdditions across all input estimators.
+        /// </summary>
+        [Fact]
+        public void StaticMerge_SumsCountAdditions_DoesNotDoubleCountFirstElement()
+        {
+            var a = new CardinalityEstimator(b: 14);
+            var b = new CardinalityEstimator(b: 14);
+            var c = new CardinalityEstimator(b: 14);
+            for (int i = 0; i < 10; i++) a.Add(i);
+            for (int i = 10; i < 25; i++) b.Add(i);
+            for (int i = 25; i < 45; i++) c.Add(i);
+
+            Assert.Equal(10UL, a.CountAdditions);
+            Assert.Equal(15UL, b.CountAdditions);
+            Assert.Equal(20UL, c.CountAdditions);
+
+            CardinalityEstimator merged = CardinalityEstimator.Merge(new[] { a, b, c });
+            Assert.Equal(45UL, merged.CountAdditions);
+
+            // Single-element merge must also be exact (not 2x).
+            CardinalityEstimator single = CardinalityEstimator.Merge(new[] { a });
+            Assert.Equal(10UL, single.CountAdditions);
+        }
+
+        /// <summary>
+        /// Regression: the copy constructor previously left <see cref="CardinalityEstimator.CountAdditions"/>
+        /// at its default (0) instead of copying it from the source. A clone must be observationally
+        /// equivalent to the original, including CountAdditions.
+        /// </summary>
+        [Fact]
+        public void CopyConstructor_PreservesCountAdditions()
+        {
+            var original = new CardinalityEstimator(b: 14);
+            for (int i = 0; i < 17; i++) original.Add(i);
+            Assert.Equal(17UL, original.CountAdditions);
+
+            var clone = new CardinalityEstimator(original);
+            Assert.Equal(original.CountAdditions, clone.CountAdditions);
+            Assert.Equal(original.Count(), clone.Count());
+        }
+
         private void RunRecreationFromData(int cardinality = 1000000)
         {
             var hll = new CardinalityEstimator();

--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -20,7 +20,8 @@ Updated System.IO.Hashing to 10.0.7
 Fixed O(n) ConcurrentCardinalityEstimator direct-count storage (ConcurrentBag -&gt; ConcurrentDictionary)
 Zero-allocation primitive Add overloads (stackalloc + span hash)
 Precomputed inverse-powers-of-two table in Count() (removes Math.Pow from hot loop)
-Bulk-write dense lookup array in serializer</PackageReleaseNotes>
+Bulk-write dense lookup array in serializer
+Fixed CardinalityEstimator.Merge(IEnumerable) double-counting CountAdditions for the seed element; copy constructor now preserves CountAdditions</PackageReleaseNotes>
         <AssemblyVersion>1.15.0.0</AssemblyVersion>
         <FileVersion>1.15.0.0</FileVersion>
         <IncludeSymbols>true</IncludeSymbols>

--- a/CardinalityEstimation/CardinalityEstimator.cs
+++ b/CardinalityEstimation/CardinalityEstimator.cs
@@ -208,6 +208,7 @@ namespace CardinalityEstimation
             }
             hashFunction = other.hashFunction;
             hashFunctionSpan = other.hashFunctionSpan;
+            CountAdditions = other.CountAdditions;
         }
 
         /// <summary>
@@ -696,8 +697,10 @@ namespace CardinalityEstimation
                 {
                     result = new CardinalityEstimator(estimator);
                 }
-
-                result.Merge(estimator);
+                else
+                {
+                    result.Merge(estimator);
+                }
             }
 
             return result;

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ These overloads route through a `GetHashCodeSpanDelegate` and avoid the byte-arr
 - Zero-allocation primitive `Add` overloads (`stackalloc` + span hash).
 - Precomputed inverse-powers-of-two table in `Count()` (removes `Math.Pow` from hot loop).
 - Bulk-write dense lookup array in serializer.
+- Fixed `CardinalityEstimator.Merge(IEnumerable)` double-counting `CountAdditions` for the seed element; copy constructor now preserves `CountAdditions`.
 
 ### 1.14.0
 - Added support for `Span<byte>`, `ReadOnlySpan<byte>`, `Memory<byte>`, and `ReadOnlyMemory<byte>` via `ICardinalityEstimatorMemory` (zero-allocation hot path).


### PR DESCRIPTION
## Issue

Reported in `CardinalityEstimator.cs` (lines 695-701):

```csharp
if (result == null)
{
    result = new CardinalityEstimator(estimator);
}
result.Merge(estimator); // re-merges the seed estimator into itself
```

`Merge(other)` does `CountAdditions += other.CountAdditions`, so the seed estimator's count is added twice.

While investigating, found a tightly coupled second bug: the copy constructor (line 186) does not copy `CountAdditions`, leaving it at the default 0. `new CardinalityEstimator(other)` therefore silently loses the running addition count -- and this bug masked the double-count above (0 + N = N for the seed). The HLL max-register merge is idempotent, so `Count()` was unaffected, but `CountAdditions` was wrong (silently for clones; would become wrong for static Merge once the copy ctor was fixed).

## Fix

- Copy ctor now copies `CountAdditions`.
- Static `Merge(IEnumerable)` only seeds from the first estimator and merges subsequent ones via an `else` branch (matches the existing pattern in `ConcurrentCardinalityEstimator.Merge`).

## Tests

Added to `CardinalityEstimatorTests.cs`:

- `CopyConstructor_PreservesCountAdditions` -- **fails on pre-fix code** (`CountAdditions` is 0 after clone instead of the source's value).
- `StaticMerge_SumsCountAdditions_DoesNotDoubleCountFirstElement` -- pins `CountAdditions == sum(inputs.CountAdditions)` for both single-element and multi-element merges. Passes pre-fix today (the two bugs cancel) but **would fail** if anyone fixed only the copy ctor without also fixing static Merge.

Full suite: **189 passed, 1 skipped, 0 failed** on both `net8.0` and `net10.0`.

## Other changes

- Added a release-notes bullet under the upcoming 1.15.0 entry in `CardinalityEstimation.csproj` and `README.md`.
- **No version bump** -- accumulates on `version-1.15`.