### PR TITLE
Fix ConcurrentCardinalityEstimator span-delegate ctor ignoring supplied delegate

### DIFF
--- a/CardinalityEstimation.Test/ConcurrentCardinalityEstimatorTests.cs
+++ b/CardinalityEstimation.Test/ConcurrentCardinalityEstimatorTests.cs
@@ -833,5 +833,40 @@ namespace CardinalityEstimation.Test
         // unit test in CardinalityEstimatorTests; both estimators now consume
         // the same table so a single regression test is sufficient.
         // ---------------------------------------------------------------------
+
+        /// <summary>
+        /// Regression: the <see cref="ConcurrentCardinalityEstimator"/> constructor that takes a
+        /// <see cref="GetHashCodeSpanDelegate"/> previously checked <c>this.hashFunction == null</c>
+        /// (which is always true at that point because the chained <c>this(state)</c> ctor never
+        /// assigns it) and unconditionally overwrote the user-supplied span delegate with the
+        /// default XxHash128 implementation. The user delegate must be honored, and a non-null
+        /// byte-array <c>hashFunction</c> companion must be wired up to it (mirrors the analogous
+        /// branch in <see cref="CardinalityEstimator(GetHashCodeSpanDelegate, CardinalityEstimatorState)"/>).
+        /// </summary>
+        [Fact]
+        public void SpanDelegateConstructor_UsesProvidedDelegateInsteadOfDefault()
+        {
+            int callCount = 0;
+            GetHashCodeSpanDelegate customSpanHash = (ReadOnlySpan<byte> bytes) =>
+            {
+                callCount++;
+                // Return a deterministic, distinctive value so default XxHash128 (which would
+                // produce arbitrary bit patterns) cannot accidentally match this fingerprint.
+                return 0xDEADBEEFCAFEBABEUL;
+            };
+
+            var state = new CardinalityEstimatorState
+            {
+                BitsPerIndex = 14,
+                IsSparse = true,
+                LookupSparse = new Dictionary<ushort, byte>(),
+                CountAdditions = 0,
+            };
+
+            using var estimator = new ConcurrentCardinalityEstimator(customSpanHash, state);
+            estimator.Add(BitConverter.GetBytes(42));
+
+            Assert.True(callCount > 0, "Custom span hash delegate was never invoked -- ctor silently replaced it with the default.");
+        }
     }
 }

--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -21,7 +21,8 @@ Fixed O(n) ConcurrentCardinalityEstimator direct-count storage (ConcurrentBag -&
 Zero-allocation primitive Add overloads (stackalloc + span hash)
 Precomputed inverse-powers-of-two table in Count() (removes Math.Pow from hot loop)
 Bulk-write dense lookup array in serializer
-Fixed CardinalityEstimator.Merge(IEnumerable) double-counting CountAdditions for the seed element; copy constructor now preserves CountAdditions</PackageReleaseNotes>
+Fixed CardinalityEstimator.Merge(IEnumerable) double-counting CountAdditions for the seed element; copy constructor now preserves CountAdditions
+Fixed ConcurrentCardinalityEstimator span-delegate constructor silently discarding the supplied delegate</PackageReleaseNotes>
         <AssemblyVersion>1.15.0.0</AssemblyVersion>
         <FileVersion>1.15.0.0</FileVersion>
         <IncludeSymbols>true</IncludeSymbols>

--- a/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
+++ b/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
@@ -246,10 +246,14 @@ namespace CardinalityEstimation
         {
             // Init the hash function
             this.hashFunctionSpan = hashFunctionSpan;
-            if (this.hashFunction == null)
+            if (this.hashFunctionSpan == null)
             {
                 this.hashFunction = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x));
                 this.hashFunctionSpan = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x));
+            }
+            else
+            {
+                this.hashFunction = (x) => hashFunctionSpan(x);
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ These overloads route through a `GetHashCodeSpanDelegate` and avoid the byte-arr
 - Precomputed inverse-powers-of-two table in `Count()` (removes `Math.Pow` from hot loop).
 - Bulk-write dense lookup array in serializer.
 - Fixed `CardinalityEstimator.Merge(IEnumerable)` double-counting `CountAdditions` for the seed element; copy constructor now preserves `CountAdditions`.
+- Fixed `ConcurrentCardinalityEstimator` span-delegate constructor silently discarding the supplied delegate.
 
 ### 1.14.0
 - Added support for `Span<byte>`, `ReadOnlySpan<byte>`, `Memory<byte>`, and `ReadOnlyMemory<byte>` via `ICardinalityEstimatorMemory` (zero-allocation hot path).


### PR DESCRIPTION
## Issue

The `ConcurrentCardinalityEstimator(GetHashCodeSpanDelegate, CardinalityEstimatorState)` constructor (`ConcurrentCardinalityEstimator.cs` lines 244-254) silently discards the supplied span delegate. It chains to `this(state)`, which never assigns `hashFunction` or `hashFunctionSpan`, so the subsequent `if (this.hashFunction == null)` check is always true and both delegates are overwritten with the default XxHash128. Any call to `new ConcurrentCardinalityEstimator(mySpanFunc, state)` ignored `mySpanFunc`.

## Fix

Mirrors the correct pattern in the analogous `CardinalityEstimator` constructor: the null check is now on `hashFunctionSpan`, and the `else` branch wires `hashFunction` to wrap the provided span delegate, so both fields are populated consistently with the caller's intent.

## Tests

Added `SpanDelegateConstructor_UsesProvidedDelegateInsteadOfDefault` in `ConcurrentCardinalityEstimatorTests`: it constructs the estimator with a custom span delegate that increments a counter and asserts the counter is non-zero after `Add`. Verified the test fails on pre-fix code and passes on the fix. Full suite: 190 passed / 1 skipped on both net8.0 and net10.0.

## Other changes

- Added a release-notes bullet under 1.15.0 in both `CardinalityEstimation.csproj` and `README.md`.
- No version bump - accumulates on `version-1.15`.