### PR TITLE
Add null-argument checks to ConcurrentCardinalityEstimator Add(string)/Add(byte[])

### DIFF
--- a/CardinalityEstimation.Test/ConcurrentCardinalityEstimatorTests.cs
+++ b/CardinalityEstimation.Test/ConcurrentCardinalityEstimatorTests.cs
@@ -868,5 +868,21 @@ namespace CardinalityEstimation.Test
 
             Assert.True(callCount > 0, "Custom span hash delegate was never invoked -- ctor silently replaced it with the default.");
         }
+
+        [Fact]
+        public void AddString_ThrowsArgumentNullException_WhenElementIsNull()
+        {
+            using var estimator = new ConcurrentCardinalityEstimator();
+            var ex = Assert.Throws<ArgumentNullException>(() => estimator.Add((string)null));
+            Assert.Equal("element", ex.ParamName);
+        }
+
+        [Fact]
+        public void AddByteArray_ThrowsArgumentNullException_WhenElementIsNull()
+        {
+            using var estimator = new ConcurrentCardinalityEstimator();
+            var ex = Assert.Throws<ArgumentNullException>(() => estimator.Add((byte[])null));
+            Assert.Equal("element", ex.ParamName);
+        }
     }
 }

--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -22,7 +22,8 @@ Zero-allocation primitive Add overloads (stackalloc + span hash)
 Precomputed inverse-powers-of-two table in Count() (removes Math.Pow from hot loop)
 Bulk-write dense lookup array in serializer
 Fixed CardinalityEstimator.Merge(IEnumerable) double-counting CountAdditions for the seed element; copy constructor now preserves CountAdditions
-Fixed ConcurrentCardinalityEstimator span-delegate constructor silently discarding the supplied delegate</PackageReleaseNotes>
+Fixed ConcurrentCardinalityEstimator span-delegate constructor silently discarding the supplied delegate
+Added null-argument validation to ConcurrentCardinalityEstimator.Add(string) and Add(byte[]) for parity with CardinalityEstimator</PackageReleaseNotes>
         <AssemblyVersion>1.15.0.0</AssemblyVersion>
         <FileVersion>1.15.0.0</FileVersion>
         <IncludeSymbols>true</IncludeSymbols>

--- a/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
+++ b/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
@@ -326,8 +326,12 @@ namespace CardinalityEstimation
         /// Add an element of type <see cref="string"/>
         /// </summary>
         /// <returns>True is estimator's state was modified. False otherwise</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> is null</exception>
         public bool Add(string element)
         {
+            if (element == null)
+                throw new ArgumentNullException(nameof(element));
+
             ThrowIfDisposed();
 
             ulong hashCode;
@@ -441,8 +445,12 @@ namespace CardinalityEstimation
         /// Add an element of type <see cref="byte[]"/>
         /// </summary>
         /// <returns>True is estimator's state was modified. False otherwise</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> is null</exception>
         public bool Add(byte[] element)
         {
+            if (element == null)
+                throw new ArgumentNullException(nameof(element));
+
             ThrowIfDisposed();
             ulong hashCode = hashFunction(element);
             bool changed = AddElementHash(hashCode);

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ These overloads route through a `GetHashCodeSpanDelegate` and avoid the byte-arr
 - Bulk-write dense lookup array in serializer.
 - Fixed `CardinalityEstimator.Merge(IEnumerable)` double-counting `CountAdditions` for the seed element; copy constructor now preserves `CountAdditions`.
 - Fixed `ConcurrentCardinalityEstimator` span-delegate constructor silently discarding the supplied delegate.
+- Added null-argument validation to `ConcurrentCardinalityEstimator.Add(string)` and `Add(byte[])` for parity with `CardinalityEstimator`.
 
 ### 1.14.0
 - Added support for `Span<byte>`, `ReadOnlySpan<byte>`, `Memory<byte>`, and `ReadOnlyMemory<byte>` via `ICardinalityEstimatorMemory` (zero-allocation hot path).


### PR DESCRIPTION
## Issue

`CardinalityEstimator.Add(string)` and `Add(byte[])` both guard against null and throw `ArgumentNullException(nameof(element))`. The corresponding overloads on `ConcurrentCardinalityEstimator` did not validate input, so passing null produced either a `NullReferenceException` (`Add(string)`, via `element.Length`) or an `ArgumentNullException` with the wrong parameter name (`Add(byte[])`, bubbling up from the underlying hash function with `ParamName = "source"`) instead of the documented contract.

## Fix

Added explicit `if (element == null) throw new ArgumentNullException(nameof(element));` guards to both overloads in `ConcurrentCardinalityEstimator.cs` so the API matches the non-concurrent class. XML docs updated to declare the exception.

## Tests

Added `AddString_ThrowsArgumentNullException_WhenElementIsNull` and `AddByteArray_ThrowsArgumentNullException_WhenElementIsNull` in `ConcurrentCardinalityEstimatorTests`. Both assert `ex.ParamName == "element"` and were verified to fail on pre-fix code (string: NullReferenceException; byte[]: ParamName was `source`). Full suite: 192 passed / 1 skipped on both net8.0 and net10.0.

## Other changes

- Release-notes bullet appended to 1.15.0 in `CardinalityEstimation.csproj` and `README.md`.
- No version bump - accumulates on `version-1.15`.