### PR TITLE
Compute m via bit shift instead of Math.Pow in estimator constructors

### DIFF
--- a/CardinalityEstimation.Test/CardinalityEstimatorTests.cs
+++ b/CardinalityEstimation.Test/CardinalityEstimatorTests.cs
@@ -713,6 +713,28 @@ namespace CardinalityEstimation.Test
             }
         }
 
+        [Theory]
+        [InlineData(4)]
+        [InlineData(10)]
+        [InlineData(14)]
+        [InlineData(16)]
+        public void Constructor_LookupDenseLength_EqualsTwoToBitsPerIndex(int bitsPerIndex)
+        {
+            // m (the number of HLL substreams / dense lookup length) must equal
+            // 2^bitsPerIndex. Constructors compute it via 1 << bitsPerIndex; this
+            // test pins that contract against the documented HLL invariant.
+            int expected = 1 << bitsPerIndex;
+            var hll = new CardinalityEstimator(b: bitsPerIndex);
+            // Force transition into the dense representation.
+            for (int i = 0; i < 5000; i++)
+            {
+                hll.Add(i);
+            }
+            var state = hll.GetState();
+            Assert.NotNull(state.LookupDense);
+            Assert.Equal(expected, state.LookupDense.Length);
+        }
+
         // ---------------------------------------------------------------------
         // Regression tests for the zero-allocation primitive Add overloads.
         //

--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -23,7 +23,8 @@ Precomputed inverse-powers-of-two table in Count() (removes Math.Pow from hot lo
 Bulk-write dense lookup array in serializer
 Fixed CardinalityEstimator.Merge(IEnumerable) double-counting CountAdditions for the seed element; copy constructor now preserves CountAdditions
 Fixed ConcurrentCardinalityEstimator span-delegate constructor silently discarding the supplied delegate
-Added null-argument validation to ConcurrentCardinalityEstimator.Add(string) and Add(byte[]) for parity with CardinalityEstimator</PackageReleaseNotes>
+Added null-argument validation to ConcurrentCardinalityEstimator.Add(string) and Add(byte[]) for parity with CardinalityEstimator
+Compute m via bit shift (1 &lt;&lt; bitsPerIndex) instead of (int)Math.Pow(2, bitsPerIndex) in constructors</PackageReleaseNotes>
         <AssemblyVersion>1.15.0.0</AssemblyVersion>
         <FileVersion>1.15.0.0</FileVersion>
         <IncludeSymbols>true</IncludeSymbols>

--- a/CardinalityEstimation/CardinalityEstimator.cs
+++ b/CardinalityEstimation/CardinalityEstimator.cs
@@ -265,7 +265,7 @@ namespace CardinalityEstimation
         {
             bitsPerIndex = state.BitsPerIndex;
             bitsForHll = (byte)(64 - bitsPerIndex);
-            m = (int) Math.Pow(2, bitsPerIndex);
+            m = 1 << bitsPerIndex;
             alphaM = GetAlphaM(m);
             subAlgorithmSelectionThreshold = GetSubAlgorithmSelectionThreshold(bitsPerIndex);
 

--- a/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
+++ b/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
@@ -172,7 +172,7 @@ namespace CardinalityEstimation
             var state = other.GetState();
             bitsPerIndex = state.BitsPerIndex;
             bitsForHll = (byte)(64 - bitsPerIndex);
-            m = (int)Math.Pow(2, bitsPerIndex);
+            m = 1 << bitsPerIndex;
             alphaM = GetAlphaM(m);
             subAlgorithmSelectionThreshold = GetSubAlgorithmSelectionThreshold(bitsPerIndex);
 
@@ -202,7 +202,7 @@ namespace CardinalityEstimation
                 var state = other.GetStateInternal();
                 bitsPerIndex = state.BitsPerIndex;
                 bitsForHll = (byte)(64 - bitsPerIndex);
-                m = (int)Math.Pow(2, bitsPerIndex);
+                m = 1 << bitsPerIndex;
                 alphaM = GetAlphaM(m);
                 subAlgorithmSelectionThreshold = GetSubAlgorithmSelectionThreshold(bitsPerIndex);
 
@@ -264,7 +264,7 @@ namespace CardinalityEstimation
         {
             bitsPerIndex = state.BitsPerIndex;
             bitsForHll = (byte)(64 - bitsPerIndex);
-            m = (int)Math.Pow(2, bitsPerIndex);
+            m = 1 << bitsPerIndex;
             alphaM = GetAlphaM(m);
             subAlgorithmSelectionThreshold = GetSubAlgorithmSelectionThreshold(bitsPerIndex);
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ These overloads route through a `GetHashCodeSpanDelegate` and avoid the byte-arr
 - Fixed `CardinalityEstimator.Merge(IEnumerable)` double-counting `CountAdditions` for the seed element; copy constructor now preserves `CountAdditions`.
 - Fixed `ConcurrentCardinalityEstimator` span-delegate constructor silently discarding the supplied delegate.
 - Added null-argument validation to `ConcurrentCardinalityEstimator.Add(string)` and `Add(byte[])` for parity with `CardinalityEstimator`.
+- Compute `m` via bit shift (`1 << bitsPerIndex`) instead of `(int)Math.Pow(2, bitsPerIndex)` in constructors.
 
 ### 1.14.0
 - Added support for `Span<byte>`, `ReadOnlySpan<byte>`, `Memory<byte>`, and `ReadOnlyMemory<byte>` via `ICardinalityEstimatorMemory` (zero-allocation hot path).


### PR DESCRIPTION
## Issue

In every constructor of both `CardinalityEstimator` and `ConcurrentCardinalityEstimator`, the substream count `m` is computed as `(int)Math.Pow(2, bitsPerIndex)`. The deserializer (`CardinalityEstimatorSerializer.Read`) already uses `1 << bitsPerIndex`. `bitsPerIndex` is constrained to [4, 16] so the shift is exact (no floating-point round-trip) and avoids a transcendental function call.

## Fix

Replaced the four call sites with `m = 1 << bitsPerIndex;`:
- `CardinalityEstimator.cs` line 268
- `ConcurrentCardinalityEstimator.cs` lines 175, 205, 267

## Tests

This is a pure mathematical refactor — `Math.Pow(2, n) == 1 << n` for any integer `n` in the supported range, so no observable behavior changes and a true regression test isn't possible (the existing 192-test suite, including accuracy and serialization round-trip tests, already exercises `m`). Added `Constructor_LookupDenseLength_EqualsTwoToBitsPerIndex` (theory, `b` ∈ {4, 10, 14, 16}) to pin the `m == 2^bitsPerIndex` contract explicitly. Full suite: 196 passed / 1 skipped on both net8.0 and net10.0.

## Other changes

- Release-notes bullet appended to 1.15.0 in `CardinalityEstimation.csproj` and `README.md`.
- No version bump - accumulates on `version-1.15`.