### PR TITLE
Document intentionally empty version-3 branch in serializer Read

### DIFF
--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -24,7 +24,8 @@ Bulk-write dense lookup array in serializer
 Fixed CardinalityEstimator.Merge(IEnumerable) double-counting CountAdditions for the seed element; copy constructor now preserves CountAdditions
 Fixed ConcurrentCardinalityEstimator span-delegate constructor silently discarding the supplied delegate
 Added null-argument validation to ConcurrentCardinalityEstimator.Add(string) and Add(byte[]) for parity with CardinalityEstimator
-Compute m via bit shift (1 &lt;&lt; bitsPerIndex) instead of (int)Math.Pow(2, bitsPerIndex) in constructors</PackageReleaseNotes>
+Compute m via bit shift (1 &lt;&lt; bitsPerIndex) instead of (int)Math.Pow(2, bitsPerIndex) in constructors
+Documented the intentionally empty version-3 branch in CardinalityEstimatorSerializer.Read</PackageReleaseNotes>
         <AssemblyVersion>1.15.0.0</AssemblyVersion>
         <FileVersion>1.15.0.0</FileVersion>
         <IncludeSymbols>true</IncludeSymbols>

--- a/CardinalityEstimation/CardinalityEstimatorSerializer.cs
+++ b/CardinalityEstimation/CardinalityEstimatorSerializer.cs
@@ -234,6 +234,9 @@ namespace CardinalityEstimation
             byte hashFunctionId;
             if (dataFormatMajorVersion >= 3)
             {
+                // Version 3.0 dropped the on-the-wire hashFunctionId byte: the hash function
+                // is now supplied by the caller (or defaults to XxHash128 in the
+                // CardinalityEstimator constructor below). Nothing additional to read here.
             }
             else if (dataFormatMajorVersion >= 2)
             {

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ These overloads route through a `GetHashCodeSpanDelegate` and avoid the byte-arr
 - Fixed `ConcurrentCardinalityEstimator` span-delegate constructor silently discarding the supplied delegate.
 - Added null-argument validation to `ConcurrentCardinalityEstimator.Add(string)` and `Add(byte[])` for parity with `CardinalityEstimator`.
 - Compute `m` via bit shift (`1 << bitsPerIndex`) instead of `(int)Math.Pow(2, bitsPerIndex)` in constructors.
+- Documented the intentionally empty version-3 branch in `CardinalityEstimatorSerializer.Read`.
 
 ### 1.14.0
 - Added support for `Span<byte>`, `ReadOnlySpan<byte>`, `Memory<byte>`, and `ReadOnlyMemory<byte>` via `ICardinalityEstimatorMemory` (zero-allocation hot path).


### PR DESCRIPTION
## Issue

`CardinalityEstimatorSerializer.Read` (lines 235-237) contained an empty `if (dataFormatMajorVersion >= 3) { }` branch which read as a stale, unfinished extension point.

## Fix

The branch is in fact functionally required: data format v3 dropped the on-the-wire `hashFunctionId` byte that v2 wrote, so the v3 path correctly reads nothing while still intercepting v3+ streams to prevent them from falling through into the v2 `else if` (which would erroneously consume a non-existent byte and corrupt the rest of the read).

Replaced the empty body with a comment explaining:
- Why nothing is read for v3+ (the byte was removed from the format).
- Where the hash function actually comes from (caller-supplied delegate, or the `CardinalityEstimator` constructor's default `XxHash128`).

## Tests

Pure documentation change — no behavior change. Existing v3 round-trip tests in `CardinalityEstimatorSerializerTests` already exercise this code path. Full suite: 196 passed / 1 skipped on both net8.0 and net10.0.

## Other changes

- Release-notes bullet appended to 1.15.0 in `CardinalityEstimation.csproj` and `README.md`.
- No version bump - accumulates on `version-1.15`.