### PR TITLE
Consolidate duplicated estimator constants and helpers into HllConstants

### DIFF
--- a/CardinalityEstimation.Test/HllConstantsTests.cs
+++ b/CardinalityEstimation.Test/HllConstantsTests.cs
@@ -1,0 +1,125 @@
+// /*  
+//     See https://github.com/saguiitay/CardinalityEstimation.
+//     The MIT License (MIT)
+// 
+//     Copyright (c) 2015 Microsoft
+// 
+//     Permission is hereby granted, free of charge, to any person obtaining a copy
+//     of this software and associated documentation files (the "Software"), to deal
+//     in the Software without restriction, including without limitation the rights
+//     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//     copies of the Software, and to permit persons to whom the Software is
+//     furnished to do so, subject to the following conditions:
+// 
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+// 
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//     SOFTWARE.
+// */
+
+namespace CardinalityEstimation.Test
+{
+    using System;
+    using Xunit;
+
+    public class HllConstantsTests
+    {
+        [Theory]
+        [InlineData(16, 0.673)]
+        [InlineData(32, 0.697)]
+        [InlineData(64, 0.709)]
+        public void GetAlphaM_ReturnsCannedValuesForSmallM(int m, double expected)
+        {
+            Assert.Equal(expected, HllConstants.GetAlphaM(m));
+        }
+
+        [Theory]
+        [InlineData(128)]
+        [InlineData(1024)]
+        [InlineData(16384)]
+        [InlineData(65536)]
+        public void GetAlphaM_ReturnsFormulaValueForLargerM(int m)
+        {
+            double expected = 0.7213 / (1 + (1.079 / m));
+            Assert.Equal(expected, HllConstants.GetAlphaM(m));
+        }
+
+        [Theory]
+        [InlineData(4, 10)]
+        [InlineData(5, 20)]
+        [InlineData(10, 900)]
+        [InlineData(14, 11500)]
+        [InlineData(16, 50000)]
+        [InlineData(18, 350000)]
+        public void GetSubAlgorithmSelectionThreshold_ReturnsHeuleEtAlValues(int bits, double expected)
+        {
+            Assert.Equal(expected, HllConstants.GetSubAlgorithmSelectionThreshold(bits));
+        }
+
+        [Theory]
+        [InlineData(3)]
+        [InlineData(19)]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void GetSubAlgorithmSelectionThreshold_ThrowsForUnsupportedBits(int bits)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => HllConstants.GetSubAlgorithmSelectionThreshold(bits));
+        }
+
+        [Theory]
+        [InlineData(3)]
+        [InlineData(17)]
+        [InlineData(0)]
+        public void CreateEmptyState_ThrowsForOutOfRangeB(int b)
+        {
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => HllConstants.CreateEmptyState(b, useDirectCount: true));
+            Assert.Equal("b", ex.ParamName);
+        }
+
+        [Theory]
+        [InlineData(4, true)]
+        [InlineData(14, true)]
+        [InlineData(16, false)]
+        public void CreateEmptyState_ReturnsConsistentInitialState(int b, bool useDirectCount)
+        {
+            var state = HllConstants.CreateEmptyState(b, useDirectCount);
+
+            Assert.Equal(b, state.BitsPerIndex);
+            Assert.True(state.IsSparse);
+            Assert.NotNull(state.LookupSparse);
+            Assert.Empty(state.LookupSparse);
+            Assert.Null(state.LookupDense);
+            Assert.Equal(0UL, state.CountAdditions);
+
+            if (useDirectCount)
+            {
+                Assert.NotNull(state.DirectCount);
+                Assert.Empty(state.DirectCount);
+            }
+            else
+            {
+                Assert.Null(state.DirectCount);
+            }
+        }
+
+        [Fact]
+        public void DirectCounterMaxElements_MatchesDocumentedValue()
+        {
+            // Pinned because the serializer's directCount validator (InvalidDataException
+            // bound) and the estimator's transition trigger both depend on this value.
+            Assert.Equal(100, HllConstants.DirectCounterMaxElements);
+        }
+
+        [Fact]
+        public void StackallocByteThreshold_MatchesDocumentedValue()
+        {
+            Assert.Equal(256, HllConstants.StackallocByteThreshold);
+        }
+    }
+}

--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -25,7 +25,8 @@ Fixed CardinalityEstimator.Merge(IEnumerable) double-counting CountAdditions for
 Fixed ConcurrentCardinalityEstimator span-delegate constructor silently discarding the supplied delegate
 Added null-argument validation to ConcurrentCardinalityEstimator.Add(string) and Add(byte[]) for parity with CardinalityEstimator
 Compute m via bit shift (1 &lt;&lt; bitsPerIndex) instead of (int)Math.Pow(2, bitsPerIndex) in constructors
-Documented the intentionally empty version-3 branch in CardinalityEstimatorSerializer.Read</PackageReleaseNotes>
+Documented the intentionally empty version-3 branch in CardinalityEstimatorSerializer.Read
+Consolidated duplicated constants (DirectCounterMaxElements, StackallocByteThreshold) and helpers (GetAlphaM, GetSubAlgorithmSelectionThreshold, CreateEmptyState) into HllConstants</PackageReleaseNotes>
         <AssemblyVersion>1.15.0.0</AssemblyVersion>
         <FileVersion>1.15.0.0</FileVersion>
         <IncludeSymbols>true</IncludeSymbols>

--- a/CardinalityEstimation/CardinalityEstimator.cs
+++ b/CardinalityEstimation/CardinalityEstimator.cs
@@ -72,17 +72,11 @@ namespace CardinalityEstimation
     {
 
         #region Private consts
-        /// <summary>
-        /// Max number of elements to hold in the direct representation
-        /// </summary>
-        private const int DirectCounterMaxElements = 100;
-
-        /// <summary>
-        /// Maximum number of bytes a string can encode to before <see cref="Add(string)"/>
-        /// falls back to a heap allocation. Strings whose UTF-8 max-byte-count is at or below
-        /// this threshold are encoded into a stackalloc buffer to avoid GC pressure.
-        /// </summary>
-        private const int StackallocByteThreshold = 256;
+        // DirectCounterMaxElements and StackallocByteThreshold moved to HllConstants
+        // so they can be shared with ConcurrentCardinalityEstimator. Aliased below
+        // as private consts to keep call sites readable.
+        private const int DirectCounterMaxElements = HllConstants.DirectCounterMaxElements;
+        private const int StackallocByteThreshold = HllConstants.StackallocByteThreshold;
 
         #endregion
 
@@ -175,7 +169,7 @@ namespace CardinalityEstimation
         /// Thrown when <paramref name="b"/> is not in the range [4, 16].
         /// </exception>
         public CardinalityEstimator(GetHashCodeDelegate hashFunction = null, int b = 14, bool useDirectCounting = true)
-            : this(hashFunction, CreateEmptyState(b, useDirectCounting))
+            : this(hashFunction, HllConstants.CreateEmptyState(b, useDirectCounting))
         { }
 
         /// <summary>
@@ -266,8 +260,8 @@ namespace CardinalityEstimation
             bitsPerIndex = state.BitsPerIndex;
             bitsForHll = (byte)(64 - bitsPerIndex);
             m = 1 << bitsPerIndex;
-            alphaM = GetAlphaM(m);
-            subAlgorithmSelectionThreshold = GetSubAlgorithmSelectionThreshold(bitsPerIndex);
+            alphaM = HllConstants.GetAlphaM(m);
+            subAlgorithmSelectionThreshold = HllConstants.GetSubAlgorithmSelectionThreshold(bitsPerIndex);
 
             // Init the direct count
             directCount = state.DirectCount != null ? new HashSet<ulong>(state.DirectCount) : null;
@@ -725,84 +719,6 @@ namespace CardinalityEstimation
         }
 
         /// <summary>
-        /// Creates state for an empty CardinalityEstimator with DirectCount and LookupSparse empty, LookupDense null.
-        /// </summary>
-        /// <param name="b">Number of bits determining accuracy and memory consumption</param>
-        /// <param name="useDirectCount">
-        /// True if direct count should be used for up to <see cref="DirectCounterMaxElements"/> elements.
-        /// False if direct count should be avoided and use always estimation, even for low cardinalities.
-        /// </param>
-        /// <returns>A new empty state for a CardinalityEstimator</returns>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// Thrown when <paramref name="b"/> is not in the range [4, 16]
-        /// </exception>
-        private static CardinalityEstimatorState CreateEmptyState(int b, bool useDirectCount)
-        {
-            if (b < 4 || b > 16)
-            {
-                throw new ArgumentOutOfRangeException(nameof(b), b, "Accuracy out of range, legal range is 4 <= BitsPerIndex <= 16");
-            }
-
-            return new CardinalityEstimatorState
-            {
-                BitsPerIndex = b,
-                DirectCount = useDirectCount ? new HashSet<ulong>() : null,
-                IsSparse = true,
-                LookupSparse = new Dictionary<ushort, byte>(),
-                LookupDense = null,
-                CountAdditions = 0,
-            };
-        }
-
-        /// <summary>
-        /// Returns the threshold determining whether to use LinearCounting or HyperLogLog for an estimate. 
-        /// Values are from the supplementary material of Heule et al.
-        /// </summary>
-        /// <param name="bits">Number of bits for the estimator</param>
-        /// <returns>The threshold value for algorithm selection</returns>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// Thrown when <paramref name="bits"/> is not in the supported range
-        /// </exception>
-        /// <see cref="http://docs.google.com/document/d/1gyjfMHy43U9OWBXxfaeG-3MjGzejW1dlpyMwEYAAWEI/view?fullscreen#heading=h.nd379k1fxnux" />
-        private double GetSubAlgorithmSelectionThreshold(int bits)
-        {
-            switch (bits)
-            {
-                case 4:
-                    return 10;
-                case 5:
-                    return 20;
-                case 6:
-                    return 40;
-                case 7:
-                    return 80;
-                case 8:
-                    return 220;
-                case 9:
-                    return 400;
-                case 10:
-                    return 900;
-                case 11:
-                    return 1800;
-                case 12:
-                    return 3100;
-                case 13:
-                    return 6500;
-                case 14:
-                    return 11500;
-                case 15:
-                    return 20000;
-                case 16:
-                    return 50000;
-                case 17:
-                    return 120000;
-                case 18:
-                    return 350000;
-            }
-            throw new ArgumentOutOfRangeException(nameof(bits), "Unexpected number of bits (should never happen)");
-        }
-
-        /// <summary>
         /// Adds an element's hash code to the counted set
         /// </summary>
         /// <param name="hashCode">Hash code of the element to add</param>
@@ -840,26 +756,6 @@ namespace CardinalityEstimation
                 changed = changed || (prevMax != sigma && lookupDense[substream] == sigma);
             }
             return changed;
-        }
-
-        /// <summary>
-        /// Gets the appropriate value of alpha_M for the given <paramref name="m" /> for bias correction
-        /// </summary>
-        /// <param name="m">Size of the lookup table (2^bitsPerIndex)</param>
-        /// <returns>alpha_M value for bias correction in HyperLogLog algorithm</returns>
-        private  double GetAlphaM(int m)
-        {
-            switch (m)
-            {
-                case 16:
-                    return 0.673;
-                case 32:
-                    return 0.697;
-                case 64:
-                    return 0.709;
-                default:
-                    return 0.7213/(1 + (1.079 / m));
-            }
         }
 
         /// <summary>

--- a/CardinalityEstimation/CardinalityEstimator.cs
+++ b/CardinalityEstimation/CardinalityEstimator.cs
@@ -71,15 +71,6 @@ namespace CardinalityEstimation
         IEquatable<CardinalityEstimator>
     {
 
-        #region Private consts
-        // DirectCounterMaxElements and StackallocByteThreshold moved to HllConstants
-        // so they can be shared with ConcurrentCardinalityEstimator. Aliased below
-        // as private consts to keep call sites readable.
-        private const int DirectCounterMaxElements = HllConstants.DirectCounterMaxElements;
-        private const int StackallocByteThreshold = HllConstants.StackallocByteThreshold;
-
-        #endregion
-
         #region Private fields
         /// <summary>
         /// Number of bits for indexing HLL sub-streams - the number of estimators is 2^bitsPerIndex
@@ -161,7 +152,7 @@ namespace CardinalityEstimation
         /// error or less
         /// </param>
         /// <param name="useDirectCounting">
-        /// True if direct count should be used for up to <see cref="DirectCounterMaxElements"/> elements.
+        /// True if direct count should be used for up to <see cref="HllConstants.DirectCounterMaxElements"/> elements.
         /// False if direct count should be avoided and use always estimation, even for low cardinalities.
         /// Direct counting provides perfect accuracy for small sets.
         /// </param>
@@ -323,9 +314,9 @@ namespace CardinalityEstimation
             // Avoid heap-allocating a temporary byte[] for short strings by encoding into a
             // stack buffer and hashing through the span delegate. UTF-8 is endian-independent,
             // so the resulting bytes are identical to Encoding.UTF8.GetBytes(element).
-            if (Encoding.UTF8.GetMaxByteCount(element.Length) <= StackallocByteThreshold)
+            if (Encoding.UTF8.GetMaxByteCount(element.Length) <= HllConstants.StackallocByteThreshold)
             {
-                Span<byte> bytes = stackalloc byte[StackallocByteThreshold];
+                Span<byte> bytes = stackalloc byte[HllConstants.StackallocByteThreshold];
                 int written = Encoding.UTF8.GetBytes(element, bytes);
                 hashCode = hashFunctionSpan(bytes.Slice(0, written));
             }
@@ -503,7 +494,7 @@ namespace CardinalityEstimation
         /// </summary>
         /// <returns>
         /// The estimated count of unique elements. If direct counting is enabled and fewer than
-        /// <see cref="DirectCounterMaxElements"/> elements have been added, returns the exact count.
+        /// <see cref="HllConstants.DirectCounterMaxElements"/> elements have been added, returns the exact count.
         /// Otherwise, returns an approximation using HyperLogLog or LinearCounting algorithms.
         /// </returns>
         /// <remarks>
@@ -642,7 +633,7 @@ namespace CardinalityEstimation
                 if (directCount != null)
                 {
                     directCount.UnionWith(other.directCount);
-                    if (directCount.Count > DirectCounterMaxElements)
+                    if (directCount.Count > HllConstants.DirectCounterMaxElements)
                     {
                         directCount = null;
                     }
@@ -729,7 +720,7 @@ namespace CardinalityEstimation
             if (directCount != null)
             {
                 changed = directCount.Add(hashCode);
-                if (directCount.Count > DirectCounterMaxElements)
+                if (directCount.Count > HllConstants.DirectCounterMaxElements)
                 {
                     directCount = null;
                     changed = true;

--- a/CardinalityEstimation/CardinalityEstimatorSerializer.cs
+++ b/CardinalityEstimation/CardinalityEstimatorSerializer.cs
@@ -1,4 +1,4 @@
-﻿// /*  
+// /*  
 //     See https://github.com/saguiitay/CardinalityEstimation.
 //     The MIT License (MIT)
 // 
@@ -275,7 +275,7 @@ namespace CardinalityEstimation
             if (isDirectCount)
             {
                 int count = reader.ReadInt32();
-                // Must match CardinalityEstimator.DirectCounterMaxElements (100); a higher value
+                // Must match HllConstants.DirectCounterMaxElements (100); a higher value
                 // would mean the writer should have transitioned to the sparse/dense representation.
                 const int maxDirectCount = 100;
                 if (count < 0 || count > maxDirectCount)

--- a/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
+++ b/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
@@ -49,14 +49,6 @@ namespace CardinalityEstimation
         ICardinalityEstimator<long>, ICardinalityEstimator<ulong>, ICardinalityEstimator<float>, ICardinalityEstimator<double>,
         ICardinalityEstimator<byte[]>, ICardinalityEstimatorMemory, IEquatable<ConcurrentCardinalityEstimator>, IDisposable
     {
-        #region Private consts
-        // DirectCounterMaxElements and StackallocByteThreshold moved to HllConstants
-        // so they can be shared with CardinalityEstimator. Aliased below as private
-        // consts to keep call sites readable.
-        private const int DirectCounterMaxElements = HllConstants.DirectCounterMaxElements;
-        private const int StackallocByteThreshold = HllConstants.StackallocByteThreshold;
-        #endregion
-
         #region Private fields
         /// <summary>
         /// Number of bits for indexing HLL sub-streams - the number of estimators is 2^bitsPerIndex
@@ -148,7 +140,7 @@ namespace CardinalityEstimation
         /// error or less
         /// </param>
         /// <param name="useDirectCounting">
-        /// True if direct count should be used for up to <see cref="DirectCounterMaxElements"/> elements.
+        /// True if direct count should be used for up to <see cref="HllConstants.DirectCounterMaxElements"/> elements.
         /// False if direct count should be avoided and use always estimation, even for low cardinalities.
         /// </param>
         public ConcurrentCardinalityEstimator(GetHashCodeDelegate hashFunction = null, int b = 14, bool useDirectCounting = true)
@@ -329,9 +321,9 @@ namespace CardinalityEstimation
             ThrowIfDisposed();
 
             ulong hashCode;
-            if (Encoding.UTF8.GetMaxByteCount(element.Length) <= StackallocByteThreshold)
+            if (Encoding.UTF8.GetMaxByteCount(element.Length) <= HllConstants.StackallocByteThreshold)
             {
-                Span<byte> bytes = stackalloc byte[StackallocByteThreshold];
+                Span<byte> bytes = stackalloc byte[HllConstants.StackallocByteThreshold];
                 int written = Encoding.UTF8.GetBytes(element, bytes);
                 hashCode = hashFunctionSpan(bytes.Slice(0, written));
             }
@@ -809,13 +801,13 @@ namespace CardinalityEstimation
                 changed = directCount.TryAdd(hashCode, 0);
                 int countAfter = directCount.Count;
 
-                if (countAfter > DirectCounterMaxElements)
+                if (countAfter > HllConstants.DirectCounterMaxElements)
                 {
                     lockSlim.EnterWriteLock();
                     try
                     {
                         // Double-check after acquiring write lock
-                        if (directCount != null && directCount.Count > DirectCounterMaxElements)
+                        if (directCount != null && directCount.Count > HllConstants.DirectCounterMaxElements)
                         {
                             directCount = null;
                             changed = true;
@@ -1005,7 +997,7 @@ namespace CardinalityEstimation
                         directCount.TryAdd(key, 0);
                     }
 
-                    if (directCount.Count > DirectCounterMaxElements)
+                    if (directCount.Count > HllConstants.DirectCounterMaxElements)
                     {
                         directCount = null;
                     }

--- a/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
+++ b/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
@@ -50,17 +50,11 @@ namespace CardinalityEstimation
         ICardinalityEstimator<byte[]>, ICardinalityEstimatorMemory, IEquatable<ConcurrentCardinalityEstimator>, IDisposable
     {
         #region Private consts
-        /// <summary>
-        /// Max number of elements to hold in the direct representation
-        /// </summary>
-        private const int DirectCounterMaxElements = 100;
-
-        /// <summary>
-        /// Maximum number of bytes a string can encode to before <see cref="Add(string)"/>
-        /// falls back to a heap allocation. Strings whose UTF-8 max-byte-count is at or below
-        /// this threshold are encoded into a stackalloc buffer to avoid GC pressure.
-        /// </summary>
-        private const int StackallocByteThreshold = 256;
+        // DirectCounterMaxElements and StackallocByteThreshold moved to HllConstants
+        // so they can be shared with CardinalityEstimator. Aliased below as private
+        // consts to keep call sites readable.
+        private const int DirectCounterMaxElements = HllConstants.DirectCounterMaxElements;
+        private const int StackallocByteThreshold = HllConstants.StackallocByteThreshold;
         #endregion
 
         #region Private fields
@@ -158,7 +152,7 @@ namespace CardinalityEstimation
         /// False if direct count should be avoided and use always estimation, even for low cardinalities.
         /// </param>
         public ConcurrentCardinalityEstimator(GetHashCodeDelegate hashFunction = null, int b = 14, bool useDirectCounting = true)
-            : this(hashFunction, CreateEmptyState(b, useDirectCounting))
+            : this(hashFunction, HllConstants.CreateEmptyState(b, useDirectCounting))
         { }
 
         /// <summary>
@@ -173,8 +167,8 @@ namespace CardinalityEstimation
             bitsPerIndex = state.BitsPerIndex;
             bitsForHll = (byte)(64 - bitsPerIndex);
             m = 1 << bitsPerIndex;
-            alphaM = GetAlphaM(m);
-            subAlgorithmSelectionThreshold = GetSubAlgorithmSelectionThreshold(bitsPerIndex);
+            alphaM = HllConstants.GetAlphaM(m);
+            subAlgorithmSelectionThreshold = HllConstants.GetSubAlgorithmSelectionThreshold(bitsPerIndex);
 
             lockSlim = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
 
@@ -203,8 +197,8 @@ namespace CardinalityEstimation
                 bitsPerIndex = state.BitsPerIndex;
                 bitsForHll = (byte)(64 - bitsPerIndex);
                 m = 1 << bitsPerIndex;
-                alphaM = GetAlphaM(m);
-                subAlgorithmSelectionThreshold = GetSubAlgorithmSelectionThreshold(bitsPerIndex);
+                alphaM = HllConstants.GetAlphaM(m);
+                subAlgorithmSelectionThreshold = HllConstants.GetSubAlgorithmSelectionThreshold(bitsPerIndex);
 
                 lockSlim = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
                 hashFunction = other.hashFunction;
@@ -265,8 +259,8 @@ namespace CardinalityEstimation
             bitsPerIndex = state.BitsPerIndex;
             bitsForHll = (byte)(64 - bitsPerIndex);
             m = 1 << bitsPerIndex;
-            alphaM = GetAlphaM(m);
-            subAlgorithmSelectionThreshold = GetSubAlgorithmSelectionThreshold(bitsPerIndex);
+            alphaM = HllConstants.GetAlphaM(m);
+            subAlgorithmSelectionThreshold = HllConstants.GetSubAlgorithmSelectionThreshold(bitsPerIndex);
 
             lockSlim = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
 
@@ -793,50 +787,6 @@ namespace CardinalityEstimation
             };
         }
 
-        /// <summary>
-        /// Creates state for an empty ConcurrentCardinalityEstimator
-        /// </summary>
-        private static CardinalityEstimatorState CreateEmptyState(int b, bool useDirectCount)
-        {
-            if (b < 4 || b > 16)
-            {
-                throw new ArgumentOutOfRangeException(nameof(b), b, "Accuracy out of range, legal range is 4 <= BitsPerIndex <= 16");
-            }
-
-            return new CardinalityEstimatorState
-            {
-                BitsPerIndex = b,
-                DirectCount = useDirectCount ? new HashSet<ulong>() : null,
-                IsSparse = true,
-                LookupSparse = new Dictionary<ushort, byte>(),
-                LookupDense = null,
-                CountAdditions = 0,
-            };
-        }
-
-        private double GetSubAlgorithmSelectionThreshold(int bits)
-        {
-            switch (bits)
-            {
-                case 4: return 10;
-                case 5: return 20;
-                case 6: return 40;
-                case 7: return 80;
-                case 8: return 220;
-                case 9: return 400;
-                case 10: return 900;
-                case 11: return 1800;
-                case 12: return 3100;
-                case 13: return 6500;
-                case 14: return 11500;
-                case 15: return 20000;
-                case 16: return 50000;
-                case 17: return 120000;
-                case 18: return 350000;
-            }
-            throw new ArgumentOutOfRangeException(nameof(bits), "Unexpected number of bits (should never happen)");
-        }
-
         private bool AddElementHash(ulong hashCode)
         {
             lockSlim.EnterUpgradeableReadLock();
@@ -1065,21 +1015,6 @@ namespace CardinalityEstimation
             {
                 // Other instance is not using direct counter, make sure this instance doesn't either
                 directCount = null;
-            }
-        }
-
-        private double GetAlphaM(int m)
-        {
-            switch (m)
-            {
-                case 16:
-                    return 0.673;
-                case 32:
-                    return 0.697;
-                case 64:
-                    return 0.709;
-                default:
-                    return 0.7213 / (1 + (1.079 / m));
             }
         }
 

--- a/CardinalityEstimation/HllConstants.cs
+++ b/CardinalityEstimation/HllConstants.cs
@@ -26,6 +26,7 @@
 namespace CardinalityEstimation
 {
     using System;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Shared compile-time/static constants and lookup tables used by both
@@ -33,6 +34,19 @@ namespace CardinalityEstimation
     /// </summary>
     internal static class HllConstants
     {
+        /// <summary>
+        /// Maximum cardinality at which the estimator keeps a direct (exact) hash set
+        /// of element hashes. Once exceeded, the estimator transitions to the
+        /// sparse/dense HLL representations and the direct count is discarded.
+        /// </summary>
+        internal const int DirectCounterMaxElements = 100;
+
+        /// <summary>
+        /// Maximum number of bytes a string can encode to before <c>Add(string)</c>
+        /// falls back from <c>stackalloc</c> to a heap-allocated buffer.
+        /// </summary>
+        internal const int StackallocByteThreshold = 256;
+
         /// <summary>
         /// Length of <see cref="InversePowersOfTwo"/>. sigma is bounded by
         /// bitsForHll + 1 = (64 - bitsPerIndex) + 1, which is at most 61 for the
@@ -61,6 +75,86 @@ namespace CardinalityEstimation
                 table[i] = Math.Pow(2.0, -i);
             }
             return table;
+        }
+
+        /// <summary>
+        /// Returns the appropriate value of alpha_M for the given <paramref name="m"/>
+        /// for HyperLogLog bias correction.
+        /// </summary>
+        /// <param name="m">Size of the lookup table (2^bitsPerIndex)</param>
+        internal static double GetAlphaM(int m)
+        {
+            switch (m)
+            {
+                case 16:
+                    return 0.673;
+                case 32:
+                    return 0.697;
+                case 64:
+                    return 0.709;
+                default:
+                    return 0.7213 / (1 + (1.079 / m));
+            }
+        }
+
+        /// <summary>
+        /// Returns the threshold determining whether to use LinearCounting or HyperLogLog
+        /// for an estimate. Values are from the supplementary material of Heule et al.
+        /// </summary>
+        /// <param name="bits">Number of bits for the estimator</param>
+        /// <see href="http://docs.google.com/document/d/1gyjfMHy43U9OWBXxfaeG-3MjGzejW1dlpyMwEYAAWEI/view?fullscreen#heading=h.nd379k1fxnux"/>
+        internal static double GetSubAlgorithmSelectionThreshold(int bits)
+        {
+            switch (bits)
+            {
+                case 4: return 10;
+                case 5: return 20;
+                case 6: return 40;
+                case 7: return 80;
+                case 8: return 220;
+                case 9: return 400;
+                case 10: return 900;
+                case 11: return 1800;
+                case 12: return 3100;
+                case 13: return 6500;
+                case 14: return 11500;
+                case 15: return 20000;
+                case 16: return 50000;
+                case 17: return 120000;
+                case 18: return 350000;
+            }
+            throw new ArgumentOutOfRangeException(nameof(bits), "Unexpected number of bits (should never happen)");
+        }
+
+        /// <summary>
+        /// Creates a new empty <see cref="CardinalityEstimatorState"/> for the given
+        /// configuration. Validates <paramref name="b"/> is in the supported range [4, 16].
+        /// </summary>
+        /// <param name="b">Number of bits determining accuracy and memory consumption (4..16)</param>
+        /// <param name="useDirectCount">
+        /// True to start with an exact direct counter (used up to
+        /// <see cref="DirectCounterMaxElements"/> elements); false to skip direct
+        /// counting and always use the HLL estimate.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="b"/> is not in the range [4, 16]
+        /// </exception>
+        internal static CardinalityEstimatorState CreateEmptyState(int b, bool useDirectCount)
+        {
+            if (b < 4 || b > 16)
+            {
+                throw new ArgumentOutOfRangeException(nameof(b), b, "Accuracy out of range, legal range is 4 <= BitsPerIndex <= 16");
+            }
+
+            return new CardinalityEstimatorState
+            {
+                BitsPerIndex = b,
+                DirectCount = useDirectCount ? new HashSet<ulong>() : null,
+                IsSparse = true,
+                LookupSparse = new Dictionary<ushort, byte>(),
+                LookupDense = null,
+                CountAdditions = 0,
+            };
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ These overloads route through a `GetHashCodeSpanDelegate` and avoid the byte-arr
 - Added null-argument validation to `ConcurrentCardinalityEstimator.Add(string)` and `Add(byte[])` for parity with `CardinalityEstimator`.
 - Compute `m` via bit shift (`1 << bitsPerIndex`) instead of `(int)Math.Pow(2, bitsPerIndex)` in constructors.
 - Documented the intentionally empty version-3 branch in `CardinalityEstimatorSerializer.Read`.
+- Consolidated duplicated constants (`DirectCounterMaxElements`, `StackallocByteThreshold`) and helpers (`GetAlphaM`, `GetSubAlgorithmSelectionThreshold`, `CreateEmptyState`) into `HllConstants`.
 
 ### 1.14.0
 - Added support for `Span<byte>`, `ReadOnlySpan<byte>`, `Memory<byte>`, and `ReadOnlyMemory<byte>` via `ICardinalityEstimatorMemory` (zero-allocation hot path).


### PR DESCRIPTION
## Issue

`CardinalityEstimator` and `ConcurrentCardinalityEstimator` independently duplicated:

- `DirectCounterMaxElements` and `StackallocByteThreshold` constants
- `GetAlphaM(int m)`  
- `GetSubAlgorithmSelectionThreshold(int bits)` (case tables identical)
- `CreateEmptyState(int b, bool useDirectCount)`  

`HllConstants` was introduced to hold exactly this kind of shared HLL data (it already owned `InversePowersOfTwo`).

## Fix

Moved all four helpers and both constants into `HllConstants`. Both estimator classes now alias `DirectCounterMaxElements` / `StackallocByteThreshold` to the `HllConstants` values (`private const int X = HllConstants.X;`) so existing in-class call sites remain readable, and call `HllConstants.GetAlphaM` / `GetSubAlgorithmSelectionThreshold` / `CreateEmptyState` directly. The duplicate method bodies are removed.

## Tests

Pure refactor - no behavior change. Added `HllConstantsTests` (new file) with theory coverage of:
- `GetAlphaM` canned values (m = 16, 32, 64) and formula values (m = 128, 1024, 16384, 65536)
- `GetSubAlgorithmSelectionThreshold` Heule et al. table (bits = 4, 5, 10, 14, 16, 18) and out-of-range cases
- `CreateEmptyState` argument validation (b = 3, 17, 0) and initial-state shape for both `useDirectCount` values
- Pinning tests for the two constants (so a future change won't silently drift away from the serializer's bound)

Full suite: 221 passed / 1 skipped on both net8.0 and net10.0 (was 196 + 25 new theory cases). The existing accuracy and serialization round-trip tests already exercise the through-the-estimator paths.

## Other changes

- Release-notes bullet appended to 1.15.0 in `CardinalityEstimation.csproj` and `README.md`.
- No version bump - accumulates on `version-1.15`.