### PR TITLE
Honor parallelismDegree in ParallelMerge; drop dead ParallelQuery variable

### DIFF
--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -26,7 +26,8 @@ Fixed ConcurrentCardinalityEstimator span-delegate constructor silently discardi
 Added null-argument validation to ConcurrentCardinalityEstimator.Add(string) and Add(byte[]) for parity with CardinalityEstimator
 Compute m via bit shift (1 &lt;&lt; bitsPerIndex) instead of (int)Math.Pow(2, bitsPerIndex) in constructors
 Documented the intentionally empty version-3 branch in CardinalityEstimatorSerializer.Read
-Consolidated duplicated constants (DirectCounterMaxElements, StackallocByteThreshold) and helpers (GetAlphaM, GetSubAlgorithmSelectionThreshold, CreateEmptyState) into HllConstants</PackageReleaseNotes>
+Consolidated duplicated constants (DirectCounterMaxElements, StackallocByteThreshold) and helpers (GetAlphaM, GetSubAlgorithmSelectionThreshold, CreateEmptyState) into HllConstants
+Honored parallelismDegree in ConcurrentCardinalityEstimator.ParallelMerge and removed dead ParallelQuery variable</PackageReleaseNotes>
         <AssemblyVersion>1.15.0.0</AssemblyVersion>
         <FileVersion>1.15.0.0</FileVersion>
         <IncludeSymbols>true</IncludeSymbols>

--- a/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
+++ b/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
@@ -696,17 +696,6 @@ namespace CardinalityEstimation
                 return new ConcurrentCardinalityEstimator(estimatorList[0]);
             }
 
-            // Use a divide-and-conquer approach for parallel merging
-            ParallelQuery<ConcurrentCardinalityEstimator> parallelOptions;
-            if (parallelismDegree.HasValue)
-            {
-                parallelOptions = estimatorList.AsParallel().WithDegreeOfParallelism(parallelismDegree.Value);
-            }
-            else
-            {
-                parallelOptions = estimatorList.AsParallel();
-            }
-
             // Merge in batches to reduce memory pressure
             const int batchSize = 8;
             var batches = estimatorList
@@ -715,7 +704,13 @@ namespace CardinalityEstimation
                 .Select(g => g.Select(x => x.estimator).ToList())
                 .ToList();
 
-            var batchResults = batches.AsParallel()
+            ParallelQuery<List<ConcurrentCardinalityEstimator>> batchQuery = batches.AsParallel();
+            if (parallelismDegree.HasValue)
+            {
+                batchQuery = batchQuery.WithDegreeOfParallelism(parallelismDegree.Value);
+            }
+
+            var batchResults = batchQuery
                 .Select(batch =>
                 {
                     var result = new ConcurrentCardinalityEstimator(batch[0]);

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ These overloads route through a `GetHashCodeSpanDelegate` and avoid the byte-arr
 - Compute `m` via bit shift (`1 << bitsPerIndex`) instead of `(int)Math.Pow(2, bitsPerIndex)` in constructors.
 - Documented the intentionally empty version-3 branch in `CardinalityEstimatorSerializer.Read`.
 - Consolidated duplicated constants (`DirectCounterMaxElements`, `StackallocByteThreshold`) and helpers (`GetAlphaM`, `GetSubAlgorithmSelectionThreshold`, `CreateEmptyState`) into `HllConstants`.
+- Honored `parallelismDegree` in `ConcurrentCardinalityEstimator.ParallelMerge` and removed dead `ParallelQuery` variable.
 
 ### 1.14.0
 - Added support for `Span<byte>`, `ReadOnlySpan<byte>`, `Memory<byte>`, and `ReadOnlyMemory<byte>` via `ICardinalityEstimatorMemory` (zero-allocation hot path).


### PR DESCRIPTION
## Issue
`ConcurrentCardinalityEstimator.ParallelMerge` (lines ~700-708) built a `ParallelQuery<ConcurrentCardinalityEstimator>` into a local `parallelOptions` that was **never used**. The actual batch work four lines later called `batches.AsParallel()` unconditionally, so the caller-supplied `parallelismDegree` was silently ignored.

## Fix
Removed the dead `parallelOptions` variable and applied `WithDegreeOfParallelism(parallelismDegree.Value)` directly to the `batches.AsParallel()` query so the parameter is honored.

## Tests
Existing `StaticParallelMerge_WithDegree_MergesAll` continues to pass. Full suite: 221 passed / 1 skipped on net8.0 and net10.0.

## Other changes
Release notes bullet added under 1.15.0; no version bump (accumulates on `version-1.15`).