### PR TITLE
Preserve hash function across CardinalityEstimator <-> Concurrent conversions

### DIFF
--- a/CardinalityEstimation.Test/ConcurrentCardinalityEstimatorTests.cs
+++ b/CardinalityEstimation.Test/ConcurrentCardinalityEstimatorTests.cs
@@ -32,6 +32,7 @@ namespace CardinalityEstimation.Test
     using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
+    using CardinalityEstimation.Hash;
     using Xunit;
 
     public class ConcurrentCardinalityEstimatorTests
@@ -856,6 +857,55 @@ namespace CardinalityEstimation.Test
             Assert.Equal(25UL, original.Count());
             Assert.Equal(25UL, snapshot.Count());
             Assert.Equal(25UL, roundTripped.Count());
+        }
+
+        [Fact]
+        public void Convert_CardinalityEstimatorToConcurrent_PreservesCustomHashFunction()
+        {
+            // Regression: the CardinalityEstimator -> ConcurrentCardinalityEstimator conversion
+            // used to silently drop the source hash function and substitute the default XxHash128,
+            // because CardinalityEstimator exposed no API to read it back. Now that HashFunction
+            // is public, the conversion preserves it (verified by reference equality).
+            GetHashCodeDelegate custom = Fnv1A.GetHashCode;
+            var source = new CardinalityEstimator(custom, b: 14);
+            source.Add("alice");
+            source.Add("bob");
+
+            using var converted = new ConcurrentCardinalityEstimator(source);
+
+            Assert.Same(custom, converted.HashFunction);
+            Assert.Equal(2UL, converted.Count());
+        }
+
+        [Fact]
+        public void Convert_ConcurrentToCardinalityEstimator_PreservesBothHashFunctions()
+        {
+            // Regression: ToCardinalityEstimator passed only the byte-array delegate to the target
+            // ctor, which then synthesised a span delegate as (x) => hashFunction(x.ToArray()).
+            // That defeated the zero-allocation span path on the converted instance. The new
+            // internal ctor that accepts both delegates is now used so both paths survive intact.
+            GetHashCodeDelegate custom = Murmur3.GetHashCode;
+            using var source = new ConcurrentCardinalityEstimator(custom, b: 14);
+            source.Add("x");
+
+            CardinalityEstimator snapshot = source.ToCardinalityEstimator();
+
+            Assert.Same(source.HashFunction, snapshot.HashFunction);
+            Assert.Same(source.HashFunctionSpan, snapshot.HashFunctionSpan);
+            Assert.Equal(1UL, snapshot.Count());
+        }
+
+        [Fact]
+        public void HashFunction_Property_ReturnsSuppliedDelegate()
+        {
+            GetHashCodeDelegate custom = Fnv1A.GetHashCode;
+            using var ccle = new ConcurrentCardinalityEstimator(custom, b: 14);
+            var cle = new CardinalityEstimator(custom, b: 14);
+
+            Assert.Same(custom, ccle.HashFunction);
+            Assert.Same(custom, cle.HashFunction);
+            Assert.NotNull(ccle.HashFunctionSpan);
+            Assert.NotNull(cle.HashFunctionSpan);
         }
 
         // ---------------------------------------------------------------------

--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -28,7 +28,8 @@ Compute m via bit shift (1 &lt;&lt; bitsPerIndex) instead of (int)Math.Pow(2, bi
 Documented the intentionally empty version-3 branch in CardinalityEstimatorSerializer.Read
 Consolidated duplicated constants (DirectCounterMaxElements, StackallocByteThreshold) and helpers (GetAlphaM, GetSubAlgorithmSelectionThreshold, CreateEmptyState) into HllConstants
 Honored parallelismDegree in ConcurrentCardinalityEstimator.ParallelMerge and removed dead ParallelQuery variable
-Replaced GetHashCode-based lock ordering in ConcurrentCardinalityEstimator.Merge/Equals with a unique per-instance ID to eliminate a deadlock window on hash collisions</PackageReleaseNotes>
+Replaced GetHashCode-based lock ordering in ConcurrentCardinalityEstimator.Merge/Equals with a unique per-instance ID to eliminate a deadlock window on hash collisions
+Exposed HashFunction/HashFunctionSpan properties on CardinalityEstimator and ConcurrentCardinalityEstimator and made cross-type conversions preserve the source hash functions losslessly</PackageReleaseNotes>
         <AssemblyVersion>1.15.0.0</AssemblyVersion>
         <FileVersion>1.15.0.0</FileVersion>
         <IncludeSymbols>true</IncludeSymbols>

--- a/CardinalityEstimation/CardinalityEstimator.cs
+++ b/CardinalityEstimation/CardinalityEstimator.cs
@@ -242,6 +242,29 @@ namespace CardinalityEstimation
         }
 
         /// <summary>
+        /// Creates a CardinalityEstimator preserving both the byte-array and span hash functions
+        /// supplied by the caller. Used by lossless conversions where both delegates of a source
+        /// estimator should be kept intact (instead of synthesising one from the other).
+        /// </summary>
+        /// <param name="hashFunction">Byte-array hash function. If null, a default XxHash128 delegate is created.</param>
+        /// <param name="hashFunctionSpan">Span hash function. If null, falls back to wrapping <paramref name="hashFunction"/>.</param>
+        /// <param name="state">The state to initialize the estimator with</param>
+        internal CardinalityEstimator(GetHashCodeDelegate hashFunction, GetHashCodeSpanDelegate hashFunctionSpan, CardinalityEstimatorState state)
+            : this(state)
+        {
+            if (hashFunction == null && hashFunctionSpan == null)
+            {
+                this.hashFunction = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x));
+                this.hashFunctionSpan = (x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x));
+            }
+            else
+            {
+                this.hashFunction = hashFunction ?? ((x) => hashFunctionSpan(x));
+                this.hashFunctionSpan = hashFunctionSpan ?? ((x) => hashFunction(x.ToArray()));
+            }
+        }
+
+        /// <summary>
         /// Creates a CardinalityEstimator from serialized state
         /// </summary>
         /// <param name="state">The state to restore the estimator from</param>
@@ -296,6 +319,21 @@ namespace CardinalityEstimation
         /// </summary>
         /// <value>The count of all addition operations performed</value>
         public ulong CountAdditions { get; private set; }
+
+        /// <summary>
+        /// Gets the byte-array hash function used by this estimator. Returned so that callers
+        /// (e.g. <see cref="ConcurrentCardinalityEstimator(CardinalityEstimator)"/>) can preserve
+        /// the original hash function across conversions and copies, making such operations lossless
+        /// even when a non-default hash was supplied.
+        /// </summary>
+        public GetHashCodeDelegate HashFunction => hashFunction;
+
+        /// <summary>
+        /// Gets the span hash function used by this estimator (the zero-allocation path used by the
+        /// <c>Span&lt;byte&gt;</c> / <c>ReadOnlySpan&lt;byte&gt;</c> / <c>Memory&lt;byte&gt;</c> overloads).
+        /// Exposed for the same lossless-conversion reason as <see cref="HashFunction"/>.
+        /// </summary>
+        public GetHashCodeSpanDelegate HashFunctionSpan => hashFunctionSpan;
         #endregion
 
         #region Public methods

--- a/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
+++ b/CardinalityEstimation/ConcurrentCardinalityEstimator.cs
@@ -179,8 +179,13 @@ namespace CardinalityEstimation
             lockSlim = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
             instanceId = Interlocked.Increment(ref instanceIdCounter);
 
-            // Init the hash function - use default since we can't get it from the other estimator
-            hashFunction = ((x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x)));
+            // Preserve the source estimator's hash functions so the conversion is lossless even
+            // when a non-default hash (e.g. Murmur3, FNV-1a, or a custom delegate) was supplied
+            // to the original CardinalityEstimator.
+            hashFunction = other.HashFunction
+                ?? ((x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x)));
+            hashFunctionSpan = other.HashFunctionSpan
+                ?? ((x) => BitConverter.ToUInt64(System.IO.Hashing.XxHash128.Hash(x)));
 
             sparseMaxElements = Math.Max(0, (m / 15) - 10);
 
@@ -322,6 +327,22 @@ namespace CardinalityEstimation
 
         #region Public properties
         public ulong CountAdditions => (ulong)Interlocked.Read(ref countAdditions);
+
+        /// <summary>
+        /// Gets the byte-array hash function used by this estimator. Returned so that callers
+        /// (e.g. <see cref="ToCardinalityEstimator"/>) can preserve the original hash function
+        /// across conversions and copies, making such operations lossless even when a non-default
+        /// hash was supplied. Safe to read without a lock — the field is set once at construction
+        /// and never reassigned afterwards.
+        /// </summary>
+        public GetHashCodeDelegate HashFunction => hashFunction;
+
+        /// <summary>
+        /// Gets the span hash function used by this estimator (the zero-allocation path used by
+        /// the <c>Span&lt;byte&gt;</c> / <c>ReadOnlySpan&lt;byte&gt;</c> / <c>Memory&lt;byte&gt;</c>
+        /// overloads). Exposed for the same lossless-conversion reason as <see cref="HashFunction"/>.
+        /// </summary>
+        public GetHashCodeSpanDelegate HashFunctionSpan => hashFunctionSpan;
         #endregion
 
         #region Public methods
@@ -628,7 +649,7 @@ namespace CardinalityEstimation
             try
             {
                 var state = GetStateInternal();
-                return new CardinalityEstimator(hashFunction, state);
+                return new CardinalityEstimator(hashFunction, hashFunctionSpan, state);
             }
             finally
             {

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ These overloads route through a `GetHashCodeSpanDelegate` and avoid the byte-arr
 - Consolidated duplicated constants (`DirectCounterMaxElements`, `StackallocByteThreshold`) and helpers (`GetAlphaM`, `GetSubAlgorithmSelectionThreshold`, `CreateEmptyState`) into `HllConstants`.
 - Honored `parallelismDegree` in `ConcurrentCardinalityEstimator.ParallelMerge` and removed dead `ParallelQuery` variable.
 - Replaced `GetHashCode`-based lock ordering in `ConcurrentCardinalityEstimator.Merge`/`Equals` with a unique per-instance ID to eliminate a deadlock window on hash collisions.
+- Exposed `HashFunction`/`HashFunctionSpan` properties on `CardinalityEstimator` and `ConcurrentCardinalityEstimator` and made cross-type conversions preserve the source hash functions losslessly.
 
 ### 1.14.0
 - Added support for `Span<byte>`, `ReadOnlySpan<byte>`, `Memory<byte>`, and `ReadOnlyMemory<byte>` via `ICardinalityEstimatorMemory` (zero-allocation hot path).


### PR DESCRIPTION
## Issue
Two cross-type conversions silently lost the source estimator's hash function:

1. `ConcurrentCardinalityEstimator(CardinalityEstimator other)` substituted the default `XxHash128` because `CardinalityEstimator` exposed no public API to read its hash function back. The constructor body even acknowledged the gap with a `// use default since we can't get it from the other estimator` comment.
2. `ConcurrentCardinalityEstimator.ToCardinalityEstimator()` forwarded only the byte-array delegate, causing the target `CardinalityEstimator` ctor to synthesise a span delegate as `(x) => hashFunction(x.ToArray())` — losing the optimized zero-allocation span path the source had.

This matters when deserializing with a custom hash (Murmur3, Fnv1A, or a user delegate) and then converting between the two estimator types: the converted instance silently used a different hash, producing different cardinality estimates and breaking `Equals`/`Merge` invariants.

## Fix
- Added public `HashFunction` and `HashFunctionSpan` get-only properties on both `CardinalityEstimator` and `ConcurrentCardinalityEstimator`.
- Added a new internal `CardinalityEstimator(GetHashCodeDelegate, GetHashCodeSpanDelegate, CardinalityEstimatorState)` constructor that preserves both delegates verbatim.
- `ConcurrentCardinalityEstimator(CardinalityEstimator)` now reads `other.HashFunction` / `other.HashFunctionSpan`; falls back to the default only when both are null.
- `ConcurrentCardinalityEstimator.ToCardinalityEstimator()` now passes both delegates to the new ctor so the span path survives.

## Tests
Three new tests in `ConcurrentCardinalityEstimatorTests`:
- `Convert_CardinalityEstimatorToConcurrent_PreservesCustomHashFunction` — pins `Assert.Same(custom, converted.HashFunction)` for a `Fnv1A` source.
- `Convert_ConcurrentToCardinalityEstimator_PreservesBothHashFunctions` — pins both delegates by reference for a `Murmur3` source.
- `HashFunction_Property_ReturnsSuppliedDelegate` — basic property contract on both types.

Each would fail on the pre-fix code (the converted instance carried the default `XxHash128` lambda, not the supplied delegate). Full suite: 226 passed / 1 skipped on net8.0 and net10.0 (was 223 + 3 new).

## Other changes
Release notes bullet added under 1.15.0; no version bump (accumulates on `version-1.15`).