### PR TITLE
Switch from coverlet.collector to dotnet-coverage local tool

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-coverage": {
+      "version": "18.6.2",
+      "commands": [
+        "dotnet-coverage"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,8 @@ FakesAssemblies/
 # Visual Studio 6 workspace options file
 *.opt
 
+
+# dotnet-coverage local output
+coverage.xml
+*.coverage
+

--- a/CardinalityEstimation.Test/CardinalityEstimation.Test.csproj
+++ b/CardinalityEstimation.Test/CardinalityEstimation.Test.csproj
@@ -8,10 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/CardinalityEstimation/CardinalityEstimation.csproj
+++ b/CardinalityEstimation/CardinalityEstimation.csproj
@@ -29,7 +29,8 @@ Documented the intentionally empty version-3 branch in CardinalityEstimatorSeria
 Consolidated duplicated constants (DirectCounterMaxElements, StackallocByteThreshold) and helpers (GetAlphaM, GetSubAlgorithmSelectionThreshold, CreateEmptyState) into HllConstants
 Honored parallelismDegree in ConcurrentCardinalityEstimator.ParallelMerge and removed dead ParallelQuery variable
 Replaced GetHashCode-based lock ordering in ConcurrentCardinalityEstimator.Merge/Equals with a unique per-instance ID to eliminate a deadlock window on hash collisions
-Exposed HashFunction/HashFunctionSpan properties on CardinalityEstimator and ConcurrentCardinalityEstimator and made cross-type conversions preserve the source hash functions losslessly</PackageReleaseNotes>
+Exposed HashFunction/HashFunctionSpan properties on CardinalityEstimator and ConcurrentCardinalityEstimator and made cross-type conversions preserve the source hash functions losslessly
+Replaced unused coverlet.collector test package with a dotnet-coverage local tool manifest</PackageReleaseNotes>
         <AssemblyVersion>1.15.0.0</AssemblyVersion>
         <FileVersion>1.15.0.0</FileVersion>
         <IncludeSymbols>true</IncludeSymbols>

--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ estimator.Add(buffer); // no allocation
 
 These overloads route through a `GetHashCodeSpanDelegate` and avoid the byte-array allocation of the legacy path.
 
+## Code Coverage
+
+Coverage is collected locally with [`dotnet-coverage`](https://learn.microsoft.com/en-us/dotnet/core/additional-tools/dotnet-coverage), pinned as a [local .NET tool](https://learn.microsoft.com/en-us/dotnet/core/tools/local-tools-how-to-use) in `.config/dotnet-tools.json`. From a fresh checkout:
+
+```bash
+dotnet tool restore
+dotnet build
+dotnet dotnet-coverage collect --output-format cobertura --output coverage.xml \
+    "dotnet test --no-build --nologo"
+```
+
+The resulting `coverage.xml` is gitignored and can be fed into ReportGenerator, Codecov, or any Cobertura-aware viewer.CI does not currently collect coverage — this is a developer-local workflow.
+
 ## Release Notes
 
 ### 1.15.0
@@ -174,6 +187,7 @@ These overloads route through a `GetHashCodeSpanDelegate` and avoid the byte-arr
 - Honored `parallelismDegree` in `ConcurrentCardinalityEstimator.ParallelMerge` and removed dead `ParallelQuery` variable.
 - Replaced `GetHashCode`-based lock ordering in `ConcurrentCardinalityEstimator.Merge`/`Equals` with a unique per-instance ID to eliminate a deadlock window on hash collisions.
 - Exposed `HashFunction`/`HashFunctionSpan` properties on `CardinalityEstimator` and `ConcurrentCardinalityEstimator` and made cross-type conversions preserve the source hash functions losslessly.
+- Replaced the unused `coverlet.collector` test package with a `dotnet-coverage` local tool manifest; coverage is now a developer-local opt-in via `dotnet tool restore` + `dotnet dotnet-coverage collect`.
 
 ### 1.14.0
 - Added support for `Span<byte>`, `ReadOnlySpan<byte>`, `Memory<byte>`, and `ReadOnlyMemory<byte>` via `ICardinalityEstimatorMemory` (zero-allocation hot path).


### PR DESCRIPTION
## Issue
The test project carried a `coverlet.collector` 10.0.0 `PackageReference` but no workflow or script ever invoked `dotnet test --collect:"XPlat Code Coverage"` — so the package was dead weight in every restore.

## Fix
Replaced `coverlet.collector` with [`dotnet-coverage`](https://learn.microsoft.com/en-us/dotnet/core/additional-tools/dotnet-coverage) pinned as a [local .NET tool](https://learn.microsoft.com/en-us/dotnet/core/tools/local-tools-how-to-use) in `.config/dotnet-tools.json`. Coverage becomes a developer-local opt-in:

```bash
dotnet tool restore
dotnet build
dotnet dotnet-coverage collect --output-format cobertura --output coverage.xml "dotnet test --no-build --nologo"
```

Added a "Code Coverage" section to `README.md` documenting the workflow, and a `coverage.xml` / `*.coverage` entry to `.gitignore`.

CI workflows (`dotnet.yml`, `manual.yml`) are intentionally unchanged — coverage is dev-local only per the chosen scope.

## Tests
Tooling-only change with no production-code impact, so no new tests. Smoke-tested locally end-to-end:
- `dotnet tool restore` succeeds.
- Full suite still runs cleanly: 226 passed / 1 skipped on net8.0 and net10.0.
- `dotnet-coverage collect` produces a valid Cobertura XML reporting 98% line / 91% branch coverage.

## Other changes
Release notes bullet added under 1.15.0; no version bump (accumulates on `version-1.15`).