### PR TITLE
Increase Merge_ConcurrentWithMemoryTypes_ThreadSafe timeout to 30s

### DIFF
--- a/CardinalityEstimation.Test/ConcurrentCardinalityEstimatorMemoryTests.cs
+++ b/CardinalityEstimation.Test/ConcurrentCardinalityEstimatorMemoryTests.cs
@@ -548,8 +548,10 @@ namespace CardinalityEstimation.Test
                 Task.Run(() => estimator1.Merge(estimator3))
             };
 
-            // Assert - Should complete without deadlock
-            var completed = Task.WaitAll(mergeTasks, TimeSpan.FromSeconds(5));
+            // Assert - Should complete without deadlock. Use a generous 30 s budget so this
+            // detects an actual deadlock while staying well clear of cold-runner scheduling
+            // jitter on shared CI workers (locally this completes in tens of milliseconds).
+            var completed = Task.WaitAll(mergeTasks, TimeSpan.FromSeconds(30));
             Assert.True(completed, "Merges should complete without deadlock");
             
             Assert.True(estimator1.Count() > 0);


### PR DESCRIPTION
## Issue

CI run [25215421113](https://github.com/saguiitay/CardinalityEstimation/actions/runs/25215421113/job/73934651522) on PR #65 (version-1.15 → master) reported one failed test on net8.0:

```
Failed CardinalityEstimation.Test.ConcurrentCardinalityEstimatorMemoryTests.Merge_ConcurrentWithMemoryTypes_ThreadSafe [5 s]
Error Message:
   Merges should complete without deadlock
Expected: True
Actual:   False
```

The duration matches the `Task.WaitAll(mergeTasks, TimeSpan.FromSeconds(5))` budget exactly — the test timed out rather than detecting an actual deadlock. Locally on Windows the same test takes ~25 ms (200x under budget). The 5 s budget is too tight for a cold ubuntu-latest runner under contention.

## Fix

Bumped the budget to 30 s (`ConcurrentCardinalityEstimatorMemoryTests.cs:552`), matching the budget already used by `Merge_CrossPairs_HighConcurrency_DoesNotDeadlock`. Added a brief comment explaining the rationale. The test still fails fast on a real deadlock.

## Tests

Test-only change. The modified test (`Merge_ConcurrentWithMemoryTypes_ThreadSafe`) passes locally on both net8.0 and net10.0; the full suite is 226 passed / 1 skipped on both TFMs.

## Other changes

No production code changes. No `<PackageReleaseNotes>` entry — flaky-test fix is not user-visible. No version bump (accumulates on `version-1.15`).